### PR TITLE
v0.3 types compatibility

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.3-
+Compat
 DataStructures
 Options

--- a/src/WaveletScattering.jl
+++ b/src/WaveletScattering.jl
@@ -1,5 +1,6 @@
 module WaveletScattering
 
+using Compat
 using DataStructures
 
 include("variables.jl")

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -4,7 +4,8 @@ immutable Literal
     symbol::Symbol
     level::Int
 end
-Literal(tup::Tuple{Symbol,Int}) = Literal(tup[1], tup[2])
+typealias SymbolInt @compat(Tuple{Symbol,Int})
+Literal(tup::SymbolInt) = Literal(tup[1], tup[2])
 Literal(sym::Symbol) = Literal(sym, 1)
 
 # A scattering Variable is a linked list of Literals.

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -10,8 +10,8 @@ Literal(sym::Symbol) = Literal(sym, 1)
 
 # A scattering Variable is a linked list of Literals.
 typealias VariableKey LinkedList{Literal}
-VariableKey() = nil(Literal)
-VariableKey(head, tail...) = cons(Literal(head), VariableKey(tail...))
+variablekey() = nil(Literal)
+variablekey(head, tail...) = cons(Literal(head), variablekey(tail...))
 
 # A scattering VariableTree is a hybrid Dict-of-Vectors recursive container
 # indexed by the scattering symbols and levels that make up a Literal.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using Base.Test
 
+using DataStructures
+
 tests = [
     "variables"
 ]

--- a/test/variables.jl
+++ b/test/variables.jl
@@ -1,4 +1,4 @@
-import WaveletScattering: Literal, VariableKey, VariableTree,
+import WaveletScattering: Literal, variablekey, VariableTree,
                           getindex, setindex!, haskey
 
 # Literal
@@ -9,12 +9,12 @@ gamma2_literal = Literal((:γ, 2))
 @test isimmutable(time_literal)
 @test isimmutable(gamma2_literal)
 
-# VariableKey
-@test isa(VariableKey(),Nil{Literal})
-variablekey = VariableKey(:time, (:γ, 2))
-@test variablekey.head == time_literal
-@test variablekey.tail.head == gamma2_literal
-@test variablekey.tail.tail == VariableKey()
+# variablekey
+@test isa(variablekey(),Nil{Literal})
+varkey = variablekey(:time, (:γ, 2))
+@test key.head == time_literal
+@test key.tail.head == gamma2_literal
+@test key.tail.tail == variablekey()
 
 # VariableTree constructor
 value = 1.0
@@ -26,14 +26,14 @@ variabletree.symbols[:time] = [VariableTree(2.0)]
 
 # VariableTree getindex
 @test variabletree[nil()] == 1.0
-@test variabletree[VariableKey(:time)] == 2.0
+@test variabletree[variablekey(:time)] == 2.0
 
 # VariableTree setindex!
-variabletree[VariableKey(:time)] = 3.0
-@test variabletree[VariableKey(:time)] == 3.0
+variabletree[variablekey(:time)] = 3.0
+@test variabletree[variablekey(:time)] == 3.0
 
 # VariableTree haskey
 @test haskey(variabletree, nil())
-@test haskey(variabletree, VariableKey(:time))
-@test !haskey(variabletree, VariableKey(:space))
-@test !haskey(variabletree, VariableKey((:time,2)))
+@test haskey(variabletree, variablekey(:time))
+@test !haskey(variabletree, variablekey(:space))
+@test !haskey(variabletree, variablekey((:time,2)))

--- a/test/variables.jl
+++ b/test/variables.jl
@@ -12,9 +12,9 @@ gamma2_literal = Literal((:γ, 2))
 # variablekey
 @test isa(variablekey(),Nil{Literal})
 varkey = variablekey(:time, (:γ, 2))
-@test key.head == time_literal
-@test key.tail.head == gamma2_literal
-@test key.tail.tail == variablekey()
+@test varkey.head == time_literal
+@test varkey.tail.head == gamma2_literal
+@test varkey.tail.tail == variablekey()
 
 # VariableTree constructor
 value = 1.0

--- a/test/variables.jl
+++ b/test/variables.jl
@@ -1,6 +1,5 @@
 import WaveletScattering: Literal, VariableKey, VariableTree,
                           getindex, setindex!, haskey
-using DataStructures
 
 # Literal
 time_literal = Literal(:time)


### PR DESCRIPTION
This PR ensures compatibility with the tuple type syntax of Julia v0.3.
It also replaces the constructor of the typealias VariableKey by the lower-case, v0.3-compatible variablekey.
