### PR TITLE
100% test coverage of variables.jl

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -47,4 +47,4 @@ end
 # Unlike getindex, which yields a value, the function subtree yields a branch
 subtree(t::VariableTree, key::Nil) = t
 subtree(t::VariableTree, key::Cons) =
-    subtree(t.symbols[key.head.symbol][key.head.level])
+    subtree(t.symbols[key.head.symbol][key.head.level], v.tail)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -47,4 +47,4 @@ end
 # Unlike getindex, which yields a value, the function subtree yields a branch
 subtree(t::VariableTree, key::Nil) = t
 subtree(t::VariableTree, key::Cons) =
-    subtree(t.symbols[key.head.symbol][key.head.level], v.tail)
+    subtree(t.symbols[key.head.symbol][key.head.level], key.tail)

--- a/test/variables.jl
+++ b/test/variables.jl
@@ -1,5 +1,5 @@
 import WaveletScattering: Literal, variablekey, VariableTree,
-                          getindex, setindex!, haskey
+                          getindex, setindex!, haskey, subtree
 
 # Literal
 time_literal = Literal(:time)

--- a/test/variables.jl
+++ b/test/variables.jl
@@ -37,3 +37,8 @@ variabletree[variablekey(:time)] = 3.0
 @test haskey(variabletree, variablekey(:time))
 @test !haskey(variabletree, variablekey(:space))
 @test !haskey(variabletree, variablekey((:time,2)))
+
+# subtree
+@test subtree(variabletree, nil())[nil()] == 1.0
+@test subtree(variabletree, nil())[variabletree(:time)] == 1.0
+@test subtree(variabletree, variablekey(:time))[nil()] == 3.0

--- a/test/variables.jl
+++ b/test/variables.jl
@@ -40,5 +40,5 @@ variabletree[variablekey(:time)] = 3.0
 
 # subtree
 @test subtree(variabletree, nil())[nil()] == 1.0
-@test subtree(variabletree, nil())[variablekey(:time)] == 1.0
+@test subtree(variabletree, nil())[variablekey(:time)] == 3.0
 @test subtree(variabletree, variablekey(:time))[nil()] == 3.0

--- a/test/variables.jl
+++ b/test/variables.jl
@@ -40,5 +40,5 @@ variabletree[variablekey(:time)] = 3.0
 
 # subtree
 @test subtree(variabletree, nil())[nil()] == 1.0
-@test subtree(variabletree, nil())[variabletree(:time)] == 1.0
+@test subtree(variabletree, nil())[variablekey(:time)] == 1.0
 @test subtree(variabletree, variablekey(:time))[nil()] == 3.0


### PR DESCRIPTION
This PR adds tests for the subtree function, bringing test coverage of variables.jl to 100%.
