### PR TITLE
AbstractSpec

### DIFF
--- a/src/WaveletScattering.jl
+++ b/src/WaveletScattering.jl
@@ -3,5 +3,7 @@ module WaveletScattering
 using Compat
 using DataStructures
 
+include("spec.jl")
 include("variables.jl")
+
 end

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -1,3 +1,13 @@
 abstract AbstractSpec
 abstract AbstractSpec1D{T<:Number} <: AbstractSpec
 abstract AbstractSpec2D{T<:Number} <: AbstractSpec
+
+function bankgammas(spec::AbstractSpec)
+    nΓs = spec.nFilters_per_octave * spec.nOctaves
+    γs = collect(0:(nΓs-1))
+    chromas = collect(0:(spec.nFilters_per_octave-1))
+    χs = repmat(chromas, spec.nOctaves)
+    octaves = collect(0:(spec.nOctaves-1))
+    js = vec(repmat(transpose(octaves), spec.nFilters_per_octave))
+    return (γs, χs, js)
+end

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -2,7 +2,7 @@ abstract AbstractSpec
 abstract AbstractSpec1D{T<:Number} <: AbstractSpec
 abstract AbstractSpec2D{T<:Number} <: AbstractSpec
 
-function bankgammas(spec::AbstractSpec)
+function specgammas(spec::AbstractSpec)
     nΓs = spec.nFilters_per_octave * spec.nOctaves
     γs = collect(0:(nΓs-1))
     chromas = collect(0:(spec.nFilters_per_octave-1))

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -1,0 +1,3 @@
+abstract AbstractSpec
+abstract AbstractSpec1D{T<:Number} <: AbstractSpec
+abstract AbstractSpec2D{T<:Number} <: AbstractSpec

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Base.Test
 using DataStructures
 
 tests = [
+    "spec",
     "variables"
 ]
 

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -34,7 +34,7 @@ spec = TestSpec1D(1, 2)
 @test χs == [0, 0]
 @test js == [0, 1]
 
-spec = TestSpec(12, 8)
+spec = TestSpec1D(12, 8)
 (γs, χs, js) = specgammas(spec)
 nWavelets = spec.nFilters_per_octave * spec.nOctaves
 @test length(γs) == nWavelets

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -2,9 +2,15 @@ immutable TestSpec1D <: AbstractSpec1D
     nFilters_per_octave::Int
     nOctaves::Int
 end
+immutable TestSpec2D <: AbstractSpec2D
+    nFilters_per_octave::Int
+    nOctaves::Int
+    nOrientations::Int
+end
 
 # abstract subtype testing
 @test TestSpec1D <: AbstractSpec
+@test TestSpec2D <: AbstractSpec
 
 # specgammas
 spec = TestSpec1D(1, 1)

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -6,27 +6,27 @@ end
 # abstract subtype testing
 @test TestSpec1D <: AbstractSpec
 
-# bankgammas
+# specgammas
 spec = TestSpec1D(1, 1)
-(γs, χs, js) = bankgammas(spec)
+(γs, χs, js) = specgammas(spec)
 @test γs == [0]
 @test χs == [0]
 @test js == [0]
 
 spec = TestSpec1D(2, 1)
-(γs, χs, js) = bankgammas(spec)
+(γs, χs, js) = specgammas(spec)
 @test γs == [0 1]
 @test χs == [0 1]
 @test js == [0 0]
 
 spec = TestSpec1D(1, 2)
-(γs, χs, js) = bankgammas(spec)
+(γs, χs, js) = specgammas(spec)
 @test γs == [0 1]
 @test χs == [0 0]
 @test js == [0 1]
 
 spec = TestSpec(12, 8)
-(γs, χs, js) = bankgammas(spec)
+(γs, χs, js) = specgammas(spec)
 nWavelets = spec.nFilters_per_octave * spec.nOctaves
 @test length(γs) == nWavelets
 @test length(χs) == nWavelets

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -1,0 +1,33 @@
+immutable TestSpec1D <: AbstractSpec1D
+    nFilters_per_octave::Int
+    nOctaves::Int
+end
+
+# abstract subtype testing
+@test TestSpec1D <: AbstractSpec
+
+# bankgammas
+spec = TestSpec1D(1, 1)
+(γs, χs, js) = bankgammas(spec)
+@test γs == [0]
+@test χs == [0]
+@test js == [0]
+
+spec = TestSpec1D(2, 1)
+(γs, χs, js) = bankgammas(spec)
+@test γs == [0 1]
+@test χs == [0 1]
+@test js == [0 0]
+
+spec = TestSpec1D(1, 2)
+(γs, χs, js) = bankgammas(spec)
+@test γs == [0 1]
+@test χs == [0 0]
+@test js == [0 1]
+
+spec = TestSpec(12, 8)
+(γs, χs, js) = bankgammas(spec)
+nWavelets = spec.nFilters_per_octave * spec.nOctaves
+@test length(γs) == nWavelets
+@test length(χs) == nWavelets
+@test length(js) == nWavelets

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -1,3 +1,6 @@
+import WaveletScattering: AbstractSpec, AbstractSpec1D, AbstractSpec2D,
+                          specgammas
+
 immutable TestSpec1D <: AbstractSpec1D
     nFilters_per_octave::Int
     nOctaves::Int
@@ -21,15 +24,15 @@ spec = TestSpec1D(1, 1)
 
 spec = TestSpec1D(2, 1)
 (γs, χs, js) = specgammas(spec)
-@test γs == [0 1]
-@test χs == [0 1]
-@test js == [0 0]
+@test γs == [0, 1]
+@test χs == [0, 1]
+@test js == [0, 0]
 
 spec = TestSpec1D(1, 2)
 (γs, χs, js) = specgammas(spec)
-@test γs == [0 1]
-@test χs == [0 0]
-@test js == [0 1]
+@test γs == [0, 1]
+@test χs == [0, 0]
+@test js == [0, 1]
 
 spec = TestSpec(12, 8)
 (γs, χs, js) = specgammas(spec)


### PR DESCRIPTION
This PR introduces the AbstractSpec abstract type, as well as its subtypes AbstractSpec1D and AbstractSpec2D. The function specgammas provides gammas, chis and js for a given concrete of AbstractSpec with fields nOctaves and nFilters_per_octave.
Test included.
