### PR TITLE
Morlet1DSpec

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.3
 Compat 0.4.10
 DataStructures 0.3.11
-Options 0.2.4

--- a/src/WaveletScattering.jl
+++ b/src/WaveletScattering.jl
@@ -1,11 +1,15 @@
 module WaveletScattering
 
+require("Options")
+
 using Compat
 using DataStructures
 using OptionsMod
 
+
 include("spec.jl")
 include("morlet1d.jl")
+
 include("variables.jl")
 
 end

--- a/src/WaveletScattering.jl
+++ b/src/WaveletScattering.jl
@@ -2,7 +2,7 @@ module WaveletScattering
 
 using Compat
 using DataStructures
-using Options
+using OptionsMod
 
 include("morlet1d.jl")
 include("spec.jl")

--- a/src/WaveletScattering.jl
+++ b/src/WaveletScattering.jl
@@ -6,8 +6,10 @@ using Compat
 using DataStructures
 using OptionsMod
 
-include("morlet1d.jl")
+
 include("spec.jl")
+include("morlet1d.jl")
+
 include("variables.jl")
 
 end

--- a/src/WaveletScattering.jl
+++ b/src/WaveletScattering.jl
@@ -2,7 +2,9 @@ module WaveletScattering
 
 using Compat
 using DataStructures
+using Options
 
+include("morlet1d.jl")
 include("spec.jl")
 include("variables.jl")
 

--- a/src/WaveletScattering.jl
+++ b/src/WaveletScattering.jl
@@ -2,7 +2,6 @@ module WaveletScattering
 
 using Compat
 using DataStructures
-using OptionsMod
 
 include("spec.jl")
 include("morlet1d.jl")

--- a/src/WaveletScattering.jl
+++ b/src/WaveletScattering.jl
@@ -1,15 +1,11 @@
 module WaveletScattering
 
-require("Options")
-
 using Compat
 using DataStructures
 using OptionsMod
 
-
 include("spec.jl")
 include("morlet1d.jl")
-
 include("variables.jl")
 
 end

--- a/src/WaveletScattering.jl
+++ b/src/WaveletScattering.jl
@@ -1,5 +1,7 @@
 module WaveletScattering
 
+require("Options")
+
 using Compat
 using DataStructures
 using OptionsMod

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -30,9 +30,12 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     end
 end
 
-function Morlet1DSpec(ɛ=eps(Float32), log2_length=15,
-                      max_qualityfactor=nFilters_per_octave, max_scale=Inf,
-                      nFilters_per_octave=1, nOctaves=Inf))
+function Morlet1DSpec(ɛ=eps(Float32),
+                      log2_length=15,
+                      max_qualityfactor=nFilters_per_octave,
+                      max_scale=Inf,
+                      nFilters_per_octave=1,
+                      nOctaves=Inf)
     Morlet1DSpec{Float32}(ɛ, log2_length, max_qualityfactor,
                           max_scale, nFilters_per_octave, nOctaves)
 end

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -16,7 +16,7 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
         if isinf(nOctaves)
             log2_nFilters_per_octave = ceil(Int, log2(nFilters_per_octave))
             log2_max_qualityfactor = ceil(Int, log2(max_qualityfactor))
-            if max_scale < (exp2(log2_length)+eps(realtype(T)))
+            if max_scale < (exp2(log2_length)+default_epsilon(T))
                 gap = max(1+log2_nFilters_per_octave, 2)
             else
                 gap = max(1+log2_nFilters_per_octave, 2+log2_max_qualityfactor)

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -9,11 +9,21 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     function call{T<:Number}(::Type{Morlet1DSpec{T}}, signaltype::Type{T};
                      ɛ=default_epsilon(T),
                      log2_length=15,
-                     nFilters_per_octave=1,
-                     max_qualityfactor=Float64(nFilters_per_octave),
+                     max_qualityfactor=nothing,
+                     nFilters_per_octave=nothing,
                      max_scale=Inf,
-                     nOctaves=Inf)
-        if isinf(nOctaves)
+                     nOctaves=nothing)
+        if max_qualityfactor==nothing
+            if nFilters_per_octave==nothing
+                max_qualityfactor = 1.0
+                nFilters_per_octave = 1
+            else
+                max_qualityfactor = Float64(nFilters_per_octave)
+            end
+        else
+            nFilters_per_octave = ceil(Int, max_qualityfactor)
+        end
+        if nOctaves==nothing
             log2_nFilters_per_octave = ceil(Int, log2(nFilters_per_octave))
             log2_max_qualityfactor = ceil(Int, log2(max_qualityfactor))
             if max_scale < (exp2(log2_length)+default_epsilon(T))

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -1,5 +1,5 @@
-immutable MorletSpec1D{T<:Number} <: AbstractSpect1D{T}
     ɛ
+immutable Morlet1DSpec{T<:Number} <: AbstractSpec1D{T}
     log2_length::Int
     max_qualityfactor
     max_scale

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -41,7 +41,7 @@ function Morlet1DSpec(opts::Options{CheckError})
     log2_nFilters_per_octave = floor(Int, log2(nFilters_per_octave))
     log2_max_qualityfactor = floor(Int, log2(max_qualityfactor))
     if max_scale < (exp2(log2_length)+eps(RealT))
-        gap = 1 + log2_nFilters_per_octave
+        gap = max(1 + log2_nFilters_per_octave, 2)
     else
         gap = max(1 + log2_nFilters_per_octave, 2 + log2_max_qualityfactor)
     end

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -30,13 +30,14 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     end
 end
 
-function Morlet1DSpec(ɛ=eps(Float32),
+function Morlet1DSpec(ɛ=eps(signaltype),
                       log2_length=15,
                       max_qualityfactor=nFilters_per_octave,
                       max_scale=Inf,
                       nFilters_per_octave=1,
-                      nOctaves=Inf)
-    Morlet1DSpec{Float32}(ɛ, log2_length, max_qualityfactor,
+                      nOctaves=Inf,
+                      signaltype=Float32)
+    Morlet1DSpec{signaltype}(ɛ, log2_length, max_qualityfactor,
                           max_scale, nFilters_per_octave, nOctaves)
 end
 

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -30,7 +30,8 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     end
 end
 
-function Morlet1DSpec(ɛ=eps(signaltype),
+function Morlet1DSpec(;
+                      ɛ=eps(signaltype),
                       log2_length=15,
                       max_qualityfactor=nFilters_per_octave,
                       max_scale=Inf,

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -39,10 +39,11 @@ function Morlet1DSpec(opts::Options{CheckError})
     # By default, the filter bank covers the whole frequency range, while
     # ensuring that wavelet scales remain below 2^log2_length
     log2_nFilters_per_octave = floor(Int, log2(nFilters_per_octave))
+    log2_max_qualityfactor = floor(Int, log2(max_qualityfactor))
     if max_scale < exp2(log2_length)
         gap = 1 + log2_nFilters_per_octave
     else
-        gap = 1 + max(log2_nFilters_per_octave, 1 + log2(max_qualityfactor))
+        gap = 1 + max(log2_nFilters_per_octave, 1 + log2_max_qualityfactor)
     end
     @defaults opts nOctaves = log2_length - gap
     @check_used opts

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -10,6 +10,7 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
                                      max_qualityfactor, max_scale,
                                      nFilters_per_octave::Int, nOctaves::Int)
         RealT = realtype(T)
+        checkspec(max_qualityfactor, nFilters_per_octave)
         new(RealT(ɛ), T, log2_length, RealT(max_qualityfactor),
             RealT(max_scale), nFilters_per_octave, nOctaves)
     end
@@ -17,21 +18,20 @@ end
 
 function Morlet1DSpec(opts::Options{CheckError})
     @defaults opts signaltype = Float32
-    T = opts[:signaltype]
+    T = signaltype
     RealT = realtype(T)
     @defaults opts ɛ = eps(RealT)
     @defaults opts log2_length = 15
     @defaults opts max_qualityfactor = one(RealT)
-    if haskey(opts.key2index, :nFilters_per_octave)
-        @defaults opts max_qualityfactor = float(opts[:nFilters_per_octave])
-    else
+    if opts[:nFilters_per_octave] == nothing
         @defaults opts max_qualityfactor = one(RealT)
+    else
+        @defaults opts max_qualityfactor = float(nFilters_per_octave)
     end
     @defaults opts max_scale = RealT(Inf)
     @defaults opts nFilters_per_octave = ceil(max_qualityfactor)
     @defaults opts nOctaves = 8
     @check_used opts
-    checkspec(opts)
     Morlet1DSpec{T}(ɛ, signaltype, log2_length, max_qualityfactor, max_scale,
                  nFilters_per_octave, nOctaves)
 end

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -1,5 +1,5 @@
 immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
-    ɛ # ::realtype(T) (imposed by inner constructor)
+    ɛ::Float64
     log2_length::Int
     max_qualityfactor::Float64
     max_scale::Float64
@@ -7,16 +7,16 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     nOctaves::Int
     signaltype::Type{T}
     function Morlet1DSpec{T}(signaltype::Type{T};
-                             ɛ=eps(realtype(T)),
+                             ɛ=default_epsilon(T),
                              log2_length=15,
                              nFilters_per_octave=1,
-                             max_qualityfactor=realtype(T)(nFilters_per_octave),
+                             max_qualityfactor=Float64(nFilters_per_octave),
                              max_scale=Inf,
                              nOctaves=Inf)
         if isinf(nOctaves)
             log2_nFilters_per_octave = ceil(Int, log2(nFilters_per_octave))
             log2_max_qualityfactor = ceil(Int, log2(max_qualityfactor))
-            if max_scale < (exp2(log2_length)+eps(RealT))
+            if max_scale < (exp2(log2_length)+eps(realtype(T)))
                 gap = max(1+log2_nFilters_per_octave, 2)
             else
                 gap = max(1+log2_nFilters_per_octave, 2+log2_max_qualityfactor)
@@ -25,19 +25,19 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
         end
         checkspec(ɛ, log2_length, max_qualityfactor,
                   max_scale, nFilters_per_octave, nOctaves)
-        new(realtype(T)(ɛ), log2_length, max_qualityfactor,
+        new(ɛ, log2_length, max_qualityfactor,
             max_scale, nFilters_per_octave, nOctaves, signaltype)
     end
 end
 
 function Morlet1DSpec(;
-                      ɛ=eps(signaltype),
+                      signaltype=Float32,
+                      ɛ=default_epsilon(Float32),
                       log2_length=15,
+                      nFilters_per_octave=1,
                       max_qualityfactor=nFilters_per_octave,
                       max_scale=Inf,
-                      nFilters_per_octave=1,
-                      nOctaves=Inf,
-                      signaltype=Float32)
+                      nOctaves=Inf)
     Morlet1DSpec{signaltype}(ɛ, log2_length, max_qualityfactor,
                              max_scale, nFilters_per_octave, nOctaves)
 end

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -40,10 +40,10 @@ function Morlet1DSpec(opts::Options{CheckError})
     # ensuring that wavelet scales remain below 2^log2_length
     log2_nFilters_per_octave = floor(Int, log2(nFilters_per_octave))
     log2_max_qualityfactor = floor(Int, log2(max_qualityfactor))
-    if max_scale < exp2(log2_length)
+    if max_scale < (exp2(log2_length)+eps(RealT))
         gap = 1 + log2_nFilters_per_octave
     else
-        gap = 1 + max(log2_nFilters_per_octave, 1 + log2_max_qualityfactor)
+        gap = max(1 + log2_nFilters_per_octave, 2 + log2_max_qualityfactor)
     end
     @defaults opts nOctaves = log2_length - gap
     @check_used opts

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -6,7 +6,7 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     nFilters_per_octave::Int
     nOctaves::Int
     signaltype::Type{T}
-    function Morlet1DSpec{T}(signaltype::Type{T},
+    function Morlet1DSpec{T}(signaltype::Type{T};
       ɛ=eps(realtype(T)),
       log2_length=15,
       max_qualityfactor=realtype(T)(nFilters_per_octave),

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -34,3 +34,15 @@ function Morlet1DSpec{T<:Number}(opts::Options)
              opts[:max_qualityfactor], opts[:max_scale],
              opts[:nFilters_per_octave], opts[:nOctaves])
 end
+
+# Real input by default
+Morlet1DSpec(opts::Options) = Morlet1DSpec(opts)
+Morlet1DSpec{Number}(opts::Options) = Morlet1DSpec{Real}(opts)
+
+# Single-precision input by default
+Morlet1DSpec{Real}(opts::Options) = Morlet1DSpec{Float32}(opts)
+Morlet1DSpec{Complex}(opts::Options) = Morlet1DSpec(Complex{Float32})(opts)
+
+# Empty options by default
+Morlet1DSpec() = Morlet1DSpec(@options)
+Morlet1DSpec{T<:Number}() = Morlet1DSpec{T}(@options)

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -7,12 +7,12 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     nOctaves::Int
     signaltype::Type{T}
     function Morlet1DSpec{T}(signaltype::Type{T};
-      ɛ=eps(realtype(T)),
-      log2_length=15,
-      max_qualityfactor=realtype(T)(nFilters_per_octave),
-      max_scale=Inf,
-      nFilters_per_octave=1,
-      nOctaves=Inf)
+                             ɛ=eps(realtype(T)),
+                             log2_length=15,
+                             max_qualityfactor=realtype(T)(nFilters_per_octave),
+                             max_scale=Inf,
+                             nFilters_per_octave=1,
+                             nOctaves=Inf)
         if isinf(nOctaves)
             log2_nFilters_per_octave = ceil(Int, log2(nFilters_per_octave))
             log2_max_qualityfactor = ceil(Int, log2(max_qualityfactor))
@@ -24,10 +24,17 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
             nOctaves = log2_length - gap
         end
         checkspec(ɛ, log2_length, max_qualityfactor,
-          max_scale, nFilters_per_octave, nOctaves)
+                  max_scale, nFilters_per_octave, nOctaves)
         new(realtype(T)(ɛ), log2_length, max_qualityfactor,
-          max_scale, nFilters_per_octave, nOctaves, signaltype)
+            max_scale, nFilters_per_octave, nOctaves, signaltype)
     end
+end
+
+function Morlet1DSpec(ɛ=eps(Float32), log2_length=15,
+                      max_qualityfactor=nFilters_per_octave, max_scale=Inf,
+                      nFilters_per_octave=1, nOctaves=Inf))
+    Morlet1DSpec{Float32}(ɛ, log2_length, max_qualityfactor,
+                          max_scale, nFilters_per_octave, nOctaves)
 end
 
 function localize{T<:Number}(spec::Morlet1DSpec{T})

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -37,8 +37,13 @@ function Morlet1DSpec(opts::Options{CheckError})
     # By default, no upper limit on the scale of the lowest-frequency wavelets.
     @defaults opts max_scale = RealT(Inf)
     # By default, the filter bank covers the whole frequency range, while
-    # ensuring that wavelet scales remain below 2^(log2_length-1)
-    gap = 2 + ceil(Int, log2(nFilters_per_octave))
+    # ensuring that wavelet scales remain below 2^log2_length
+    log2_nFilters_per_octave = floor(Int, log2(nFilters_per_octave))
+    if max_scale < exp2(log2_length)
+        gap = 1 + log2_nFilters_per_octave
+    else
+        gap = 1 + max(log2_nFilters_per_octave, 1 + log2(max_qualityfactor))
+    end
     @defaults opts nOctaves = log2_length - gap
     @check_used opts
     Morlet1DSpec{T}(ɛ, log2_length, max_qualityfactor, max_scale,

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -1,0 +1,16 @@
+immutable MorletSpec1D{T<:Number} <: AbstractSpect1D{T}
+    ɛ
+    log2_length::Int
+    max_qualityfactor
+    max_scale
+    nFilters_per_octave::Int
+    nOctaves::Int
+    function Morlet1DSpec{T<:Number}(ɛ, log2_length, max_qualityfactor,
+                                     max_scale, nFilters_per_octave, nOctaves)
+        @assert isa(ɛ, realtype(T))
+        @assert isa(max_qualityfactor, realtype(T))
+        @assert isa(max_scale, realtype(T))
+        new(ɛ, log2_length, max_qualityfactor, max_scale,
+            nFilters_per_octave, nOctaves)
+    end
+end

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -40,7 +40,7 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     end
 end
 
-Morlet1DSpec(T=Float32 ; args...) = Morlet1DSpec{T}(T ; args...)
+Morlet1DSpec(T=Float32; args...) = Morlet1DSpec{T}(T; args...)
 
 function localize{T<:Number}(spec::Morlet1DSpec{T})
     RealT = realtype(T)

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -29,7 +29,7 @@ function Morlet1DSpec(opts::Options{CheckError})
         @defaults opts max_qualityfactor = float(nFilters_per_octave)
     end
     @defaults opts max_scale = RealT(Inf)
-    @defaults opts nFilters_per_octave = ceil(max_qualityfactor)
+    @defaults opts nFilters_per_octave = ceil(Int, max_qualityfactor)
     @defaults opts nOctaves = 8
     @check_used opts
     Morlet1DSpec{T}(ɛ, signaltype, log2_length, max_qualityfactor, max_scale,

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -35,7 +35,7 @@ function Morlet1DSpec(opts::Options{CheckError})
     end
     @defaults opts nFilters_per_octave = ceil(Int, max_qualityfactor)
     # By default, no upper limit on the scale of the lowest-frequency wavelets.
-    @defaults opts max_scale = RealT(1 << log2_length)
+    @defaults opts max_scale = RealT(Inf)
     # By default, the filter bank covers the whole frequency range, while
     # ensuring that wavelet scales remain below 2^(log2_length-1)
     gap = 2 + ceil(Int, log2(nFilters_per_octave))

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -63,5 +63,6 @@ function localize{T<:Number}(spec::Morlet1DSpec{T})
     unbounded_qualityfactors = scales .* centerfrequencies / scale_multiplier
     qualityfactors = clamp(unbounded_qualityfactors, 1.0, spec.max_qualityfactor)
     bandwidths = resolutions ./ qualityfactors
+    scales = scale_multiplier * qualityfactors./centerfrequencies
     return (bandwidths, centerfrequencies, qualityfactors, scales)
 end

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -15,7 +15,7 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     end
 end
 
-function Morlet1DSpec{T<:Number}(opts::Options)
+function Morlet1DSpec{T<:Number}(opts::Options{CheckError})
     RealT = realtype(T)
     @defaults opts ɛ = eps(RealT)
     @defaults opts log2_length = 15

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -39,21 +39,8 @@ function Morlet1DSpec(opts::Options{CheckError})
     @defaults opts max_scale = RealT(Inf)
     # By default, the filter bank covers the whole frequency range, while
     # ensuring that wavelet scales remain below 2^(log2_length-1)
-    gap_a = ceil(Int, log2(nFilters_per_octave)) + 1
-    scale_multiplier = sqrt(log(RealT(10.0))/log(RealT(2.0)))
-    mother_centerfrequency = nFilters_per_octave==1 ? RealT(0.39) :
-        RealT(inv(3.0 - exp2(-1.0/nFilters_per_octave)))
-    mother_scale = scale_multiplier / mother_centerfrequency
-    gap_b = 1 + Int(div(log2(mother_scale) - 1.0/nFilters_per_octave, 1))
-    minimum_gap = max(gap_a, gap_b)
-    @defaults opts nOctaves = log2_length - minimum_gap
-    if (log2_length-nOctaves)<minimum_gap
-        error("Wavelet support is too large in low frequencies.\n",
-        "Either increase log2_length or decrease nOctaves.\n",
-        "log2_length = ", log2_length, "\n",
-        "nOctaves = ", nOctaves, "\n",
-        "The gap should be at least ", minimum_gap, ".")
-    end
+    @defaults opts nOctaves =
+        log2_length - 1 - max(1, ceil(Int, log2(nFilters_per_octave)))
     @check_used opts
     Morlet1DSpec{T}(ɛ, signaltype, log2_length, max_qualityfactor, max_scale,
                  nFilters_per_octave, nOctaves)

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -1,4 +1,4 @@
-immutable Morlet1DSpec{T<:Number} <: AbstractSpec1D{T}
+immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     ɛ # ::realtype(T) (imposed by inner constructor)
     signaltype::Type{T}
     log2_length::Int
@@ -6,7 +6,7 @@ immutable Morlet1DSpec{T<:Number} <: AbstractSpec1D{T}
     max_scale # ::realtype(T) (imposed by inner constructor)
     nFilters_per_octave::Int
     nOctaves::Int
-    function Morlet1DSpec{T<:Number}(ɛ, signaltype::Type{T}, log2_length,
+    function Morlet1DSpec(ɛ, signaltype::Type{T}, log2_length,
                                      max_qualityfactor, max_scale,
                                      nFilters_per_octave, nOctaves)
         RealT = realtype(T)

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -15,7 +15,9 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     end
 end
 
-function Morlet1DSpec{T<:Number}(opts::Options{CheckError})
+function Morlet1DSpec(opts::Options{CheckError})
+    @defaults opts signaltype = Float32
+    T = opts[:signaltype]
     RealT = realtype(T)
     @defaults opts ɛ = eps(RealT)
     @defaults opts log2_length = 15
@@ -30,19 +32,9 @@ function Morlet1DSpec{T<:Number}(opts::Options{CheckError})
     @defaults opts nOctaves = 8
     @check_used opts
     checkspec(opts)
-    Morlet1DSpec{precision}(opts[:ɛ], opts[:log2_length],
-             opts[:max_qualityfactor], opts[:max_scale],
-             opts[:nFilters_per_octave], opts[:nOctaves])
+    Morlet1DSpec{T}(ɛ, signaltype, log2_length, max_qualityfactor, max_scale,
+                 nFilters_per_octave, nOctaves)
 end
-
-# Real input by default
-Morlet1DSpec(opts::Options) = Morlet1DSpec(opts)
-Morlet1DSpec{Number}(opts::Options) = Morlet1DSpec{Real}(opts)
-
-# Single-precision input by default
-Morlet1DSpec{Real}(opts::Options) = Morlet1DSpec{Float32}(opts)
-Morlet1DSpec{Complex}(opts::Options) = Morlet1DSpec(Complex{Float32})(opts)
 
 # Empty options by default
 Morlet1DSpec() = Morlet1DSpec(@options)
-Morlet1DSpec{T<:Number}() = Morlet1DSpec{T}(@options)

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -6,12 +6,11 @@ immutable Morlet1DSpec{T<:Number} <: AbstractSpec1D{T}
     max_scale # ::realtype(T) (imposed by inner constructor)
     nFilters_per_octave::Int
     nOctaves::Int
-    function Morlet1DSpec{T<:Number}(ɛ, log2_length, max_qualityfactor,
-                                     max_scale, nFilters_per_octave, nOctaves)
-        @assert isa(ɛ, realtype(T))
-        @assert isa(max_qualityfactor, realtype(T))
-        @assert isa(max_scale, realtype(T))
-        new{T}(ɛ, log2_length, max_qualityfactor, max_scale,
-            nFilters_per_octave, nOctaves)
+    function Morlet1DSpec{T<:Number}(ɛ, signaltype::Type{T}, log2_length,
+                                     max_qualityfactor, max_scale,
+                                     nFilters_per_octave, nOctaves)
+        RealT = realtype(T)
+        new(RealT(ɛ), T, log2_length, RealT(max_qualityfactor),
+            RealT(max_scale), nFilters_per_octave, nOctaves)
     end
 end

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -17,7 +17,7 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
 end
 
 function Morlet1DSpec(opts::Options{CheckError})
-    @defaults opts signaltype = Float32
+    @defaults opts signaltype=Float32
     T = signaltype
     RealT = realtype(T)
     @defaults opts ɛ = eps(RealT)

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -35,7 +35,7 @@ function Morlet1DSpec(opts::Options{CheckError})
     end
     @defaults opts nFilters_per_octave = ceil(Int, max_qualityfactor)
     # By default, no upper limit on the scale of the lowest-frequency wavelets.
-    @defaults opts max_scale = RealT(Inf)
+    @defaults opts max_scale = RealT(1 << log2_length)
     # By default, the filter bank covers the whole frequency range, while
     # ensuring that wavelet scales remain below 2^(log2_length-1)
     gap = 2 + ceil(Int, log2(nFilters_per_octave))

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -6,7 +6,7 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     nFilters_per_octave::Int
     nOctaves::Int
     signaltype::Type{T}
-    function Morlet1DSpec{T}(signaltype::Type{T};
+    function Morlet1DSpec(signaltype::Type{T};
       ɛ=eps(realtype(T)),
       log2_length=15,
       max_qualityfactor=realtype(T)(nFilters_per_octave),

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -6,7 +6,7 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     nFilters_per_octave::Int
     nOctaves::Int
     signaltype::Type{T}
-    function Morlet1DSpec(signaltype::Type{T};
+    function Morlet1DSpec{T}(signaltype::Type{T};
       ɛ=eps(realtype(T)),
       log2_length=15,
       max_qualityfactor=realtype(T)(nFilters_per_octave),

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -64,5 +64,9 @@ function localize{T<:Number}(spec::Morlet1DSpec{T})
     qualityfactors = clamp(unbounded_qualityfactors, 1.0, spec.max_qualityfactor)
     bandwidths = resolutions ./ qualityfactors
     scales = scale_multiplier * qualityfactors./centerfrequencies
+    if scales[end]>exp2(spec.log2_length)
+        error("""Wavelet support is too large in low frequencies.
+        Either increase log2_length or decrease nOctaves""")
+    end
     return (bandwidths, centerfrequencies, qualityfactors, scales)
 end

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -6,9 +6,9 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     max_scale # ::realtype(T) (imposed by inner constructor)
     nFilters_per_octave::Int
     nOctaves::Int
-    function Morlet1DSpec(ɛ, signaltype::Type{T}, log2_length,
+    function Morlet1DSpec(ɛ, signaltype::Type{T}, log2_length::Int,
                                      max_qualityfactor, max_scale,
-                                     nFilters_per_octave, nOctaves)
+                                     nFilters_per_octave::Int, nOctaves::Int)
         RealT = realtype(T)
         new(RealT(ɛ), T, log2_length, RealT(max_qualityfactor),
             RealT(max_scale), nFilters_per_octave, nOctaves)

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -37,9 +37,23 @@ function Morlet1DSpec(opts::Options{CheckError})
     @defaults opts nFilters_per_octave = ceil(Int, max_qualityfactor)
     # By default, no upper limit on the scale of the lowest-frequency wavelets.
     @defaults opts max_scale = RealT(Inf)
-    # By default, the filter bank covers the whole frequency range
-    log2_nFilters_per_octave = ceil(Int, log2(nFilters_per_octave))
-    @defaults opts nOctaves = log2_length - log2_nFilters_per_octave - 1
+    # By default, the filter bank covers the whole frequency range, while
+    # ensuring that wavelet scales remain below 2^(log2_length-1)
+    gap_a = ceil(Int, log2(nFilters_per_octave)) + 1
+    scale_multiplier = sqrt(log(RealT(10.0))/log(RealT(2.0)))
+    mother_centerfrequency = nFilters_per_octave==1 ? RealT(0.39) :
+        RealT(inv(3.0 - exp2(-1.0/nFilters_per_octave)))
+    mother_scale = scale_multiplier / mother_centerfrequency
+    gap_b = 1 + Int(div(log2(mother_scale) - 1.0/nFilters_per_octave, 1))
+    minimum_gap = max(gap_a, gap_b)
+    @defaults opts nOctaves = log2_length - minimum_gap
+    if (log2_length-nOctaves)<minimum_gap
+        error("Wavelet support is too large in low frequencies.\n",
+        "Either increase log2_length or decrease nOctaves.\n",
+        "log2_length = ", log2_length, "\n",
+        "nOctaves = ", nOctaves, "\n",
+        "The gap should be at least ", minimum_gap, ".")
+    end
     @check_used opts
     Morlet1DSpec{T}(ɛ, signaltype, log2_length, max_qualityfactor, max_scale,
                  nFilters_per_octave, nOctaves)

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -44,5 +44,5 @@ function Morlet1DSpec(opts::Options{CheckError})
                  nFilters_per_octave, nOctaves)
 end
 
-# Empty options by default
+# A zero-argument constructor falls back to default options, see above
 Morlet1DSpec() = Morlet1DSpec(@options)

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -38,7 +38,7 @@ function Morlet1DSpec(opts::Options{CheckError})
     @defaults opts max_scale = RealT(Inf)
     # By default, the filter bank covers the whole frequency range, while
     # ensuring that wavelet scales remain below 2^(log2_length-1)
-    gap = max(2, 1+ceil(Int, log2(nFilters_per_octave)))
+    gap = 2 + ceil(Int, log2(nFilters_per_octave))
     @defaults opts nOctaves = log2_length - gap
     @check_used opts
     Morlet1DSpec{T}(ɛ, log2_length, max_qualityfactor, max_scale,

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -6,13 +6,13 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     nFilters_per_octave::Int
     nOctaves::Int
     signaltype::Type{T}
-    function Morlet1DSpec{T}(signaltype::Type{T};
-                             ɛ=default_epsilon(T),
-                             log2_length=15,
-                             nFilters_per_octave=1,
-                             max_qualityfactor=Float64(nFilters_per_octave),
-                             max_scale=Inf,
-                             nOctaves=Inf)
+    function call{T<:Number}(::Type{Morlet1DSpec{T}}, signaltype::Type{T};
+                     ɛ=default_epsilon(T),
+                     log2_length=15,
+                     nFilters_per_octave=1,
+                     max_qualityfactor=Float64(nFilters_per_octave),
+                     max_scale=Inf,
+                     nOctaves=Inf)
         if isinf(nOctaves)
             log2_nFilters_per_octave = ceil(Int, log2(nFilters_per_octave))
             log2_max_qualityfactor = ceil(Int, log2(max_qualityfactor))
@@ -25,22 +25,12 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
         end
         checkspec(ɛ, log2_length, max_qualityfactor,
                   max_scale, nFilters_per_octave, nOctaves)
-        new(ɛ, log2_length, max_qualityfactor,
+        new{T}(ɛ, log2_length, max_qualityfactor,
             max_scale, nFilters_per_octave, nOctaves, signaltype)
     end
 end
 
-function Morlet1DSpec(;
-                      signaltype=Float32,
-                      ɛ=default_epsilon(Float32),
-                      log2_length=15,
-                      nFilters_per_octave=1,
-                      max_qualityfactor=nFilters_per_octave,
-                      max_scale=Inf,
-                      nOctaves=Inf)
-    Morlet1DSpec{signaltype}(ɛ, log2_length, max_qualityfactor,
-                             max_scale, nFilters_per_octave, nOctaves)
-end
+Morlet1DSpec(T=Float32 ; args...) = Morlet1DSpec{T}(T ; args...)
 
 function localize{T<:Number}(spec::Morlet1DSpec{T})
     RealT = realtype(T)

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -10,7 +10,8 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
                                      max_qualityfactor, max_scale,
                                      nFilters_per_octave::Int, nOctaves::Int)
         RealT = realtype(T)
-        checkspec(max_qualityfactor, nFilters_per_octave)
+        checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
+            nFilters_per_octave, nOctaves)
         new(RealT(ɛ), T, log2_length, RealT(max_qualityfactor),
             RealT(max_scale), nFilters_per_octave, nOctaves)
     end

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -38,8 +38,8 @@ function Morlet1DSpec(opts::Options{CheckError})
     @defaults opts max_scale = RealT(Inf)
     # By default, the filter bank covers the whole frequency range, while
     # ensuring that wavelet scales remain below 2^log2_length
-    log2_nFilters_per_octave = floor(Int, log2(nFilters_per_octave))
-    log2_max_qualityfactor = floor(Int, log2(max_qualityfactor))
+    log2_nFilters_per_octave = ceil(Int, log2(nFilters_per_octave))
+    log2_max_qualityfactor = ceil(Int, log2(max_qualityfactor))
     if max_scale < (exp2(log2_length)+eps(RealT))
         gap = max(1 + log2_nFilters_per_octave, 2)
     else

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -23,8 +23,8 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
             end
             nOctaves = log2_length - gap
         end
-        checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
-          nFilters_per_octave, nOctaves)
+        checkspec(ɛ, log2_length, max_qualityfactor,
+          max_scale, nFilters_per_octave, nOctaves)
         new(realtype(T)(ɛ), log2_length, max_qualityfactor,
           max_scale, nFilters_per_octave, nOctaves, signaltype)
     end

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -1,8 +1,8 @@
 immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     ɛ # ::realtype(T) (imposed by inner constructor)
     log2_length::Int
-    max_qualityfactor # ::realtype(T) (imposed by inner constructor)
-    max_scale # ::realtype(T) (imposed by inner constructor)
+    max_qualityfactor::Float64
+    max_scale::Float64
     nFilters_per_octave::Int
     nOctaves::Int
     signaltype::Type{T}
@@ -11,8 +11,8 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
         RealT = realtype(T)
         checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
             nFilters_per_octave, nOctaves)
-        new(RealT(ɛ), log2_length, RealT(max_qualityfactor),
-            RealT(max_scale), nFilters_per_octave, nOctaves, signaltype)
+        new(RealT(ɛ), log2_length, max_qualityfactor,
+            max_scale, nFilters_per_octave, nOctaves, signaltype)
     end
 end
 

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -38,7 +38,8 @@ function Morlet1DSpec(opts::Options{CheckError})
     # By default, no upper limit on the scale of the lowest-frequency wavelets.
     @defaults opts max_scale = RealT(Inf)
     # By default, the filter bank covers the whole frequency range
-    @defaults opts nOctaves = log2_length - 1
+    log2_nFilters_per_octave = ceil(Int, log2(nFilters_per_octave))
+    @defaults opts nOctaves = log2_length - log2_nFilters_per_octave - 1
     @check_used opts
     Morlet1DSpec{T}(ɛ, signaltype, log2_length, max_qualityfactor, max_scale,
                  nFilters_per_octave, nOctaves)

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -1,8 +1,9 @@
-    ɛ
 immutable Morlet1DSpec{T<:Number} <: AbstractSpec1D{T}
+    ɛ # ::realtype(T) (imposed by inner constructor)
+    signaltype::Type{T}
     log2_length::Int
-    max_qualityfactor
-    max_scale
+    max_qualityfactor # ::realtype(T) (imposed by inner constructor)
+    max_scale # ::realtype(T) (imposed by inner constructor)
     nFilters_per_octave::Int
     nOctaves::Int
     function Morlet1DSpec{T<:Number}(ɛ, log2_length, max_qualityfactor,

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -14,3 +14,23 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
             RealT(max_scale), nFilters_per_octave, nOctaves)
     end
 end
+
+function Morlet1DSpec{T<:Number}(opts::Options)
+    RealT = realtype(T)
+    @defaults opts ɛ = eps(RealT)
+    @defaults opts log2_length = 15
+    @defaults opts max_qualityfactor = one(RealT)
+    if haskey(opts.key2index, :nFilters_per_octave)
+        @defaults opts max_qualityfactor = float(opts[:nFilters_per_octave])
+    else
+        @defaults opts max_qualityfactor = one(RealT)
+    end
+    @defaults opts max_scale = RealT(Inf)
+    @defaults opts nFilters_per_octave = ceil(max_qualityfactor)
+    @defaults opts nOctaves = 8
+    @check_used opts
+    checkspec(opts)
+    Morlet1DSpec{precision}(opts[:ɛ], opts[:log2_length],
+             opts[:max_qualityfactor], opts[:max_scale],
+             opts[:nFilters_per_octave], opts[:nOctaves])
+end

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -1,19 +1,18 @@
 immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     ɛ # ::realtype(T) (imposed by inner constructor)
-    signaltype::Type{T}
     log2_length::Int
     max_qualityfactor # ::realtype(T) (imposed by inner constructor)
     max_scale # ::realtype(T) (imposed by inner constructor)
     nFilters_per_octave::Int
     nOctaves::Int
-    function Morlet1DSpec(ɛ, signaltype::Type{T}, log2_length::Int,
-                                     max_qualityfactor, max_scale,
-                                     nFilters_per_octave::Int, nOctaves::Int)
+    signaltype::Type{T}
+    function Morlet1DSpec(ɛ, log2_length::Int, max_qualityfactor, max_scale,
+                          nFilters_per_octave::Int, nOctaves::Int, signaltype)
         RealT = realtype(T)
         checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
             nFilters_per_octave, nOctaves)
-        new(RealT(ɛ), T, log2_length, RealT(max_qualityfactor),
-            RealT(max_scale), nFilters_per_octave, nOctaves)
+        new(RealT(ɛ), log2_length, RealT(max_qualityfactor),
+            RealT(max_scale), nFilters_per_octave, nOctaves, signaltype)
     end
 end
 
@@ -42,8 +41,8 @@ function Morlet1DSpec(opts::Options{CheckError})
     gap = max(2, 1+ceil(Int, log2(nFilters_per_octave)))
     @defaults opts nOctaves = log2_length - gap
     @check_used opts
-    Morlet1DSpec{T}(ɛ, signaltype, log2_length, max_qualityfactor, max_scale,
-                 nFilters_per_octave, nOctaves)
+    Morlet1DSpec{T}(ɛ, log2_length, max_qualityfactor, max_scale,
+                 nFilters_per_octave, nOctaves, signaltype)
 end
 
 # A zero-argument constructor falls back to default options, see above
@@ -65,9 +64,5 @@ function localize{T<:Number}(spec::Morlet1DSpec{T})
     qualityfactors = clamp(unbounded_qualityfactors, 1.0, spec.max_qualityfactor)
     bandwidths = resolutions ./ qualityfactors
     scales = scale_multiplier * qualityfactors./centerfrequencies
-    if scales[end]>exp2(spec.log2_length)
-        error("""Wavelet support is too large in low frequencies.
-        Either increase log2_length or decrease nOctaves""")
-    end
     return (bandwidths, centerfrequencies, qualityfactors, scales)
 end

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -9,9 +9,9 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
     function Morlet1DSpec{T}(signaltype::Type{T};
                              ɛ=eps(realtype(T)),
                              log2_length=15,
+                             nFilters_per_octave=1,
                              max_qualityfactor=realtype(T)(nFilters_per_octave),
                              max_scale=Inf,
-                             nFilters_per_octave=1,
                              nOctaves=Inf)
         if isinf(nOctaves)
             log2_nFilters_per_octave = ceil(Int, log2(nFilters_per_octave))

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -17,20 +17,28 @@ immutable Morlet1DSpec{T<:Number} <: Abstract1DSpec{T}
 end
 
 function Morlet1DSpec(opts::Options{CheckError})
+    # Single-precision real input by default
     @defaults opts signaltype=Float32
     T = signaltype
     RealT = realtype(T)
+    # Default threshold is equal to floating-point machine precision, i.e. the
+    # distance between 1.0 and the next numbe of type RealT.
     @defaults opts ɛ = eps(RealT)
+    # Default window length is 32768 samples, i.e. about 740 ms at 44.1kHz
     @defaults opts log2_length = 15
+    # max_qualityfactor and nFilters_per_octave are mutual defaults.
+    # If none is present, both are set to one.
     @defaults opts max_qualityfactor = one(RealT)
     if opts[:nFilters_per_octave] == nothing
         @defaults opts max_qualityfactor = one(RealT)
     else
         @defaults opts max_qualityfactor = float(opts[:nFilters_per_octave])
     end
-    @defaults opts max_scale = RealT(Inf)
     @defaults opts nFilters_per_octave = ceil(Int, max_qualityfactor)
-    @defaults opts nOctaves = 8
+    # By default, no upper limit on the scale of the lowest-frequency wavelets.
+    @defaults opts max_scale = RealT(Inf)
+    # By default, the filter bank covers the whole frequency range
+    @defaults opts nOctaves = log2_length - 1
     @check_used opts
     Morlet1DSpec{T}(ɛ, signaltype, log2_length, max_qualityfactor, max_scale,
                  nFilters_per_octave, nOctaves)

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -26,7 +26,7 @@ function Morlet1DSpec(opts::Options{CheckError})
     if opts[:nFilters_per_octave] == nothing
         @defaults opts max_qualityfactor = one(RealT)
     else
-        @defaults opts max_qualityfactor = float(nFilters_per_octave)
+        @defaults opts max_qualityfactor = float(opts[:nFilters_per_octave])
     end
     @defaults opts max_scale = RealT(Inf)
     @defaults opts nFilters_per_octave = ceil(Int, max_qualityfactor)

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -10,7 +10,7 @@ immutable MorletSpec1D{T<:Number} <: AbstractSpect1D{T}
         @assert isa(ɛ, realtype(T))
         @assert isa(max_qualityfactor, realtype(T))
         @assert isa(max_scale, realtype(T))
-        new(ɛ, log2_length, max_qualityfactor, max_scale,
+        new{T}(ɛ, log2_length, max_qualityfactor, max_scale,
             nFilters_per_octave, nOctaves)
     end
 end

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -39,7 +39,7 @@ function Morlet1DSpec(;
                       nOctaves=Inf,
                       signaltype=Float32)
     Morlet1DSpec{signaltype}(ɛ, log2_length, max_qualityfactor,
-                          max_scale, nFilters_per_octave, nOctaves)
+                             max_scale, nFilters_per_octave, nOctaves)
 end
 
 function localize{T<:Number}(spec::Morlet1DSpec{T})

--- a/src/morlet1d.jl
+++ b/src/morlet1d.jl
@@ -29,7 +29,6 @@ function Morlet1DSpec(opts::Options{CheckError})
     @defaults opts log2_length = 15
     # max_qualityfactor and nFilters_per_octave are mutual defaults.
     # If none is present, both are set to one.
-    @defaults opts max_qualityfactor = one(RealT)
     if opts[:nFilters_per_octave] == nothing
         @defaults opts max_qualityfactor = one(RealT)
     else
@@ -40,8 +39,8 @@ function Morlet1DSpec(opts::Options{CheckError})
     @defaults opts max_scale = RealT(Inf)
     # By default, the filter bank covers the whole frequency range, while
     # ensuring that wavelet scales remain below 2^(log2_length-1)
-    @defaults opts nOctaves =
-        log2_length - 1 - max(1, ceil(Int, log2(nFilters_per_octave)))
+    gap = max(2, 1+ceil(Int, log2(nFilters_per_octave)))
+    @defaults opts nOctaves = log2_length - gap
     @check_used opts
     Morlet1DSpec{T}(ɛ, signaltype, log2_length, max_qualityfactor, max_scale,
                  nFilters_per_octave, nOctaves)

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -7,10 +7,8 @@ abstract Abstract2DSpec{T<:Number} <: AbstractSpec
 # Littlewood-Paley inequality. See documentation for details.
 function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
   nFilters_per_octave, nOctaves)
-    for (k,v) in Dict("ɛ"=>ɛ, "log2_length"=>log2_length,
-      "max_qualityfactor"=>max_qualityfactor,
-      "nFilters_per_octave"=>nFilters_per_octave, "nOctaves"=>nOctaves)
-        isfinite(v) || errror(k, "cannot be infinite")
+    if isinf(ɛ)
+      error("ɛ must be finite. A typical value is 1e-4.")
     end
     if ɛ>=one(ɛ) || ɛ<zero(ɛ)
         error("ɛ must be in [0.0, 1.0[. A typical value is 1e-4.")
@@ -41,6 +39,9 @@ function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
         must be satisfied. Either increase log2_length, decrease nOctaves,
         or decrease nFilters_per_octave.""")
     end
+    if isinf(max_qualityfactor)
+        error("max_qualityfactor must be finite.")
+    end
     if max_qualityfactor < 1.0
         error("Too small maximum quality factor.\n",
         "max_qualityfactor = ", max_qualityfactor, "\n",
@@ -64,6 +65,7 @@ function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
         """The inequality nFilters_per_octave≧max_qualityfactor must be
         satisfied.""")
     end
+    return true
 end
 
 # realtype provides the type parameter of a complex type e.g. Complex{Float32}.

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -30,7 +30,7 @@ function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
         "nOctaves = ", nOctaves, "\n",
         "The difference (log2_length-nOctaves) must be ≧2.")
     end
-    if (log2_length-nOctaves) <= 1+log2(nFilters_per_octave)
+    if (log2_length-nOctaves) < 1+log2(nFilters_per_octave)
         error("Too many filters per octave for the given length.\n",
         "log2_length = ", log2_length, "\n",
         "log2(nFilters_per_octave) = ", log2(nFilters_per_octave), "\n",

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -30,7 +30,7 @@ function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
         "nOctaves = ", nOctaves, "\n",
         "The difference (log2_length-nOctaves) must be ≧2.")
     end
-    if (log2_length-nOctaves) <= log2(nFilters_per_octave)
+    if (log2_length-nOctaves) <= 1+log2(nFilters_per_octave)
         error("Too many filters per octave for the given length.\n",
         "log2_length = ", log2_length, "\n",
         "log2(nFilters_per_octave) = ", log2(nFilters_per_octave), "\n",
@@ -58,7 +58,7 @@ function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
         "nFilters_per_octave = ", nFilters_per_octave, "\n",
         "nFilters_per_octave must be ≧1.")
     end
-    if max_qualityfactor > oftype(max_qualityfactor, nFilters_per_octave)
+    if max_qualityfactor > nFilters_per_octave
         error("Too few filters per octave for the given quality factor.\n",
         "max_qualityfactor = ", max_qualityfactor, "\n",
         "nFilters_per_octave = ", nFilters_per_octave, "\n",

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -31,9 +31,6 @@ function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
         "log2_length = ", log2_length, "\n",
         "log2_length must be ≧2")
     end
-    if isinf(log2_length)
-        error("Signal length must be finite.\n log2_length = ", log2_length)
-    end
     if nOctaves < 1
         error("Too few octaves.\n",
         "nOctaves = ", nOctaves, "\n",

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -86,6 +86,15 @@ default_epsilon(T::Type{Float32}) = 1e-7
 default_epsilon(T::Type{Float64}) = 1e-15
 default_epsilon{RealT}(T::Type{Complex{RealT}}) = default_epsilon(RealT)
 
+
+"""Provides the type parameter of a complex type.
+
+For example, realtype(Complex{Float32}) yields Float32.
+For numeric real types, e.g. Float32, it is a no-op."""
+realtype{T<:Real}(::Type{T}) = T
+realtype{T<:Real}(::Type{Complex{T}}) = T
+
+
 """Yields log-scales γs, chromas χs, and octaves js of a given spec.
 
 The input spec should have fields nFilters_per_octave and nOctaves."""

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -1,3 +1,4 @@
+# A Spec object contains the immutable specifications of a filter bank
 abstract AbstractSpec
 abstract AbstractSpec1D{T<:Number} <: AbstractSpec
 abstract AbstractSpec2D{T<:Number} <: AbstractSpec
@@ -11,3 +12,6 @@ function specgammas(spec::AbstractSpec)
     js = vec(repmat(transpose(octaves), spec.nFilters_per_octave))
     return (γs, χs, js)
 end
+
+realtype{T<:Real}(::Type{T}) = T
+realtype{T<:Real}(::Type{Complex{T}}) = T

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -1,7 +1,7 @@
 # A Spec object contains the immutable specifications of a filter bank
 abstract AbstractSpec
 abstract Abstract1DSpec{T<:Number} <: AbstractSpec
-abstract Abstract1DSpec{T<:Number} <: AbstractSpec
+abstract Abstract2DSpec{T<:Number} <: AbstractSpec
 
 function specgammas(spec::AbstractSpec)
     nΓs = spec.nFilters_per_octave * spec.nOctaves

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -30,7 +30,7 @@ function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
         "nOctaves = ", nOctaves, "\n",
         "The difference (log2_length-nOctaves) must be ≧2.")
     end
-    if (log2_length-nOctaves) < 1+log2(nFilters_per_octave)
+    if (log2_length-nOctaves) < 1+floor(log2(nFilters_per_octave))
         error("Too many filters per octave for the given length.\n",
         "log2_length = ", log2_length, "\n",
         "log2(nFilters_per_octave) = ", log2(nFilters_per_octave), "\n",

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -75,7 +75,7 @@ realtype{T<:Real}(::Type{T}) = T
 realtype{T<:Real}(::Type{Complex{T}}) = T
 
 """Yields log-scales γs, chromas χs, and octaves js of a given spec.
-The input should have fields nFilters_per_octave and nOctaves."""
+The input spec should have fields nFilters_per_octave and nOctaves."""
 function specgammas(spec::AbstractSpec)
   nΓs = spec.nFilters_per_octave * spec.nOctaves
   γs = collect(0:(nΓs-1))

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -6,14 +6,20 @@ abstract Abstract2DSpec{T<:Number} <: AbstractSpec
 
 """Enforces properties of the wavelets to satisfy null mean, limited spatial
 support, and Littlewood-Paley inequality.
+
 * The truncation threshold ɛ must be in [0.0, 1.0[.
+
 * The signal length must be a power of two above 4.
+
 * The maximum required quality factor must be between 1.0 and the number of
-  filters per octaves.
+filters per octaves.
+
 * The maximum scale must be at least 5 times above the maximum quality factor.
+
 * The lowest center frequency must be higher than 1, i.e. log2_length>nOctaves.
-* The lowest center frequency must be higher than half the number of filters
-  per octaves, i.e. (log2_length-nOctaves) >= log2(nFilters_per_octave).
+
+* The lowest center frequency must be higher than half the number of
+filters per octaves, i.e. (log2_length-nOctaves) >= log2(nFilters_per_octave).
 """
 function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
   nFilters_per_octave, nOctaves)
@@ -73,12 +79,14 @@ function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
 end
 
 """Provides the type parameter of a complex type.
+
 For example, realtype(Complex{Float32}) yields Float32.
 For numeric real types, e.g. Float32, it is a no-op."""
 realtype{T<:Real}(::Type{T}) = T
 realtype{T<:Real}(::Type{Complex{T}}) = T
 
 """Yields log-scales γs, chromas χs, and octaves js of a given spec.
+
 The input spec should have fields nFilters_per_octave and nOctaves."""
 function specgammas(spec::AbstractSpec)
   nΓs = spec.nFilters_per_octave * spec.nOctaves

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -5,7 +5,24 @@ abstract Abstract2DSpec{T<:Number} <: AbstractSpec
 
 # checkspec enforces properties of the wavelets to satisfy null mean and
 # Littlewood-Paley inequality. See documentation for details.
-function checkspec(max_qualityfactor, nFilters_per_octave)
+function checkspec(log2_length, max_qualityfactor, nFilters_per_octave, nOctaves)
+  if (log2_length-nOctaves)<2
+      error("Wavelet support is too large in low frequencies.\n",
+      "Either increase log2_length or decrease nOctaves.\n",
+      "log2_length = ", log2_length, "\n",
+      "nOctaves = ", nOctaves, "\n",
+      "The gap should be at least 2.")
+  end
+  if (log2_length-nOctaves)<log2(nFilters_per_octave)-1
+    error("Too many filters per octave for the given length.\n",
+    "Either increase log2_length, decrease nOctaves, ",
+    "or decrease nFilters_per_octave.\n",
+    "log2_length = ", log2_length, "\n",
+    "log2(nFilters_per_octave) = ", log2(nFilters_per_octave), "\n",
+    "nOctaves = ", nOctaves, ".\n"
+    "The inequality log2_length-nOctaves>log2(nFilters_per_octave) should ",
+    "be satisfied.")
+  end
   max_qualityfactor>=1.0 || error("max_qualityfactor cannot be lower than 1.0.")
   nFilters_per_octave>=1 || error("nFilters_per_octave cannot be lower than 1.")
   max_qualityfactor<=oftype(max_qualityfactor, nFilters_per_octave) ||

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -3,6 +3,8 @@ abstract AbstractSpec
 abstract Abstract1DSpec{T<:Number} <: AbstractSpec
 abstract Abstract2DSpec{T<:Number} <: AbstractSpec
 
+# checkspec enforces properties of the wavelets to satisfy null mean and
+# Littlewood-Paley inequality. See documentation for details.
 function checkspec(opts::Options)
     if opts[:max_qualityfactor]<1.0
         error("max_qualityfactor cannot be lower than 1.0.")
@@ -12,9 +14,12 @@ function checkspec(opts::Options)
     end
 end
 
+# realtype provides the type parameter of a complex type e.g. Complex{Float32}.
+# For numeric real types, e.g. Float32, it is a no-op.
 realtype{T<:Real}(::Type{T}) = T
 realtype{T<:Real}(::Type{Complex{T}}) = T
 
+# specgammas yields log-scales γs, chromas χs, and octaves js of a given spec.
 function specgammas(spec::AbstractSpec)
     nΓs = spec.nFilters_per_octave * spec.nOctaves
     γs = collect(0:(nΓs-1))

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -1,7 +1,7 @@
 # A Spec object contains the immutable specifications of a filter bank
 abstract AbstractSpec
-abstract AbstractSpec1D{T<:Number} <: AbstractSpec
-abstract AbstractSpec2D{T<:Number} <: AbstractSpec
+abstract Abstract1DSpec{T<:Number} <: AbstractSpec
+abstract Abstract1DSpec{T<:Number} <: AbstractSpec
 
 function specgammas(spec::AbstractSpec)
     nΓs = spec.nFilters_per_octave * spec.nOctaves

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -3,6 +3,18 @@ abstract AbstractSpec
 abstract Abstract1DSpec{T<:Number} <: AbstractSpec
 abstract Abstract2DSpec{T<:Number} <: AbstractSpec
 
+function checkspec(opts::Options)
+    if opts[:max_qualityfactor]<1.0
+        error("max_qualityfactor cannot be lower than 1.0.")
+    end
+    if opts[:max_qualityfactor]>opts[:nFilters_per_octave]
+        error("max_qualityfactor cannot be greater than nFilters_per_octave.")
+    end
+end
+
+realtype{T<:Real}(::Type{T}) = T
+realtype{T<:Real}(::Type{Complex{T}}) = T
+
 function specgammas(spec::AbstractSpec)
     nΓs = spec.nFilters_per_octave * spec.nOctaves
     γs = collect(0:(nΓs-1))
@@ -12,6 +24,3 @@ function specgammas(spec::AbstractSpec)
     js = vec(repmat(transpose(octaves), spec.nFilters_per_octave))
     return (γs, χs, js)
 end
-
-realtype{T<:Real}(::Type{T}) = T
-realtype{T<:Real}(::Type{Complex{T}}) = T

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -5,13 +5,11 @@ abstract Abstract2DSpec{T<:Number} <: AbstractSpec
 
 # checkspec enforces properties of the wavelets to satisfy null mean and
 # Littlewood-Paley inequality. See documentation for details.
-function checkspec(opts::Options)
-    if opts[:max_qualityfactor]<1.0
-        error("max_qualityfactor cannot be lower than 1.0.")
-    end
-    if opts[:max_qualityfactor]>opts[:nFilters_per_octave]
-        error("max_qualityfactor cannot be greater than nFilters_per_octave.")
-    end
+function checkspec(max_qualityfactor, nFilters_per_octave)
+  max_qualityfactor<1.0 || error("max_qualityfactor cannot be lower than 1.0.")
+  nFilters_per_octave<1 || error("nFilters_per_octave cannot be lower than 1.")
+  qualityfactor>nFilters_per_octave ||
+      error("max_qualityfactor cannot be lower than nFilters_per_octave")
 end
 
 # realtype provides the type parameter of a complex type e.g. Complex{Float32}.

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -5,42 +5,64 @@ abstract Abstract2DSpec{T<:Number} <: AbstractSpec
 
 # checkspec enforces properties of the wavelets to satisfy null mean and
 # Littlewood-Paley inequality. See documentation for details.
-function checkspec(ɛ, log2_length, max_qualityfactor,
-    nFilters_per_octave, nOctaves)
+function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
+  nFilters_per_octave, nOctaves)
+    for (k,v) in Dict("ɛ"=>ɛ, "log2_length"=>log2_length,
+      "max_qualityfactor"=>max_qualityfactor,
+      "nFilters_per_octave"=>nFilters_per_octave, "nOctaves"=>nOctaves)
+        isfinite(v) || errror(k, "cannot be infinite")
+    end
     if ɛ>=one(ɛ) || ɛ<zero(ɛ)
-        error("ɛ should be in [0.0, 1.0[. A typical value is 1e-4.")
+        error("ɛ must be in [0.0, 1.0[. A typical value is 1e-4.")
     end
-    if log2_length<2
-        error("log2_length cannot be lower than 2.")
+    if log2_length < 2
+        error("Too short signal length.\n",
+        "log2_length = ", log2_length, "\n",
+        "log2_length must be ≧2")
     end
-    if nOctaves<1
-        error("nOctaves cannot be lower than 1.")
+    if nOctaves < 1
+        error("Too few octaves.\n",
+        "nOctaves = ", nOctaves, "\n",
+        "nOctaves must be ≧1")
     end
-    if (log2_length-nOctaves)<2
+    if (log2_length-nOctaves) < 2
         error("Wavelet support is too large in low frequencies.\n",
         "Either increase log2_length or decrease nOctaves.\n",
         "log2_length = ", log2_length, "\n",
         "nOctaves = ", nOctaves, "\n",
-        "The gap should be at least 2.")
+        "The difference (log2_length-nOctaves) must be ≧2.")
     end
-    if (log2_length-nOctaves) < (1+log2(nFilters_per_octave))
+    if (log2_length-nOctaves) <= log2(nFilters_per_octave)
         error("Too many filters per octave for the given length.\n",
-        "Either increase log2_length, decrease nOctaves, ",
-        "or decrease nFilters_per_octave.\n",
         "log2_length = ", log2_length, "\n",
         "log2(nFilters_per_octave) = ", log2(nFilters_per_octave), "\n",
-        "nOctaves = ", nOctaves, ".\n"
-        "The inequality log2_length-nOctaves > log2(nFilters_per_octave) ",
-        "should be satisfied.")
+        "nOctaves = ", nOctaves, "\n",
+        """The inequality log2_length-nOctaves > log2(nFilters_per_octave)
+        must be satisfied. Either increase log2_length, decrease nOctaves,
+        or decrease nFilters_per_octave.""")
     end
-    if max_qualityfactor<1.0
-        error("max_qualityfactor cannot be lower than 1.0.")
+    if max_qualityfactor < 1.0
+        error("Too small maximum quality factor.\n",
+        "max_qualityfactor = ", max_qualityfactor, "\n",
+        "max_qualityfactor must be ≧1.0.")
     end
-    if nFilters_per_octave<1
-        error("nFilters_per_octave cannot be lower than 1.")
+    if max_scale < (5.0*max_qualityfactor)
+        error("Too small maximum scale for the given quality factor.\n",
+        "max_qualityfactor = ", max_qualityfactor, "\n",
+        "max_scale = ", max_scale, "\n",
+        "The ratio (max_qualityfactor/max_scale) must be ≧5.0.")
     end
-    if max_qualityfactor>oftype(max_qualityfactor, nFilters_per_octave)
-        error("max_qualityfactor cannot be greater than nFilters_per_octave")
+    if nFilters_per_octave < 1
+        error("Too few filters per octave.\n",
+        "nFilters_per_octave = ", nFilters_per_octave, "\n",
+        "nFilters_per_octave must be ≧1.")
+    end
+    if max_qualityfactor > oftype(max_qualityfactor, nFilters_per_octave)
+        error("Too few filters per octave for the given quality factor.\n",
+        "max_qualityfactor = ", max_qualityfactor, "\n",
+        "nFilters_per_octave = ", nFilters_per_octave, "\n",
+        """The inequality nFilters_per_octave≧max_qualityfactor must be
+        satisfied.""")
     end
 end
 

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -68,12 +68,14 @@ function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
     return true
 end
 
-# realtype provides the type parameter of a complex type e.g. Complex{Float32}.
-# For numeric real types, e.g. Float32, it is a no-op.
+"""Provides the type parameter of a complex type.
+For example, realtype(Complex{Float32}) yields Float32.
+For numeric real types, e.g. Float32, it is a no-op."""
 realtype{T<:Real}(::Type{T}) = T
 realtype{T<:Real}(::Type{Complex{T}}) = T
 
-# specgammas yields log-scales γs, chromas χs, and octaves js of a given spec.
+"""Yields log-scales γs, chromas χs, and octaves js of a given spec.
+The input should have fields nFilters_per_octave and nOctaves."""
 function specgammas(spec::AbstractSpec)
   nΓs = spec.nFilters_per_octave * spec.nOctaves
   γs = collect(0:(nΓs-1))

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -78,12 +78,10 @@ function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
     return true
 end
 
-"""Provides the type parameter of a complex type.
-
-For example, realtype(Complex{Float32}) yields Float32.
-For numeric real types, e.g. Float32, it is a no-op."""
-realtype{T<:Real}(::Type{T}) = T
-realtype{T<:Real}(::Type{Complex{T}}) = T
+default_epsilon(T::Type{Float16}) = 1e-3
+default_epsilon(T::Type{Float32}) = 1e-7
+default_epsilon(T::Type{Float64}) = 1e-15
+default_epsilon{RealT}(T::Type{Complex{RealT}}) = default_epsilon(RealT)
 
 """Yields log-scales γs, chromas χs, and octaves js of a given spec.
 

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -22,7 +22,7 @@ filters per octaves.
 filters per octaves, i.e. (log2_length-nOctaves) >= log2(nFilters_per_octave).
 """
 function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
-  nFilters_per_octave, nOctaves)
+                  nFilters_per_octave, nOctaves)
     if ɛ>=one(ɛ) || ɛ<zero(ɛ)
         error("ɛ must be in [0.0, 1.0[. A typical value is 1e-4.")
     end
@@ -96,11 +96,11 @@ realtype{T<:Real}(::Type{Complex{T}}) = T
 
 The input spec should have fields nFilters_per_octave and nOctaves."""
 function specgammas(spec::AbstractSpec)
-  nΓs = spec.nFilters_per_octave * spec.nOctaves
-  γs = collect(0:(nΓs-1))
-  chromas = collect(0:(spec.nFilters_per_octave-1))
-  χs = repmat(chromas, spec.nOctaves)
-  octaves = collect(0:(spec.nOctaves-1))
-  js = vec(repmat(transpose(octaves), spec.nFilters_per_octave))
-  return (γs, χs, js)
+    nΓs = spec.nFilters_per_octave * spec.nOctaves
+    γs = collect(0:(nΓs-1))
+    chromas = collect(0:(spec.nFilters_per_octave-1))
+    χs = repmat(chromas, spec.nOctaves)
+    octaves = collect(0:(spec.nOctaves-1))
+    js = vec(repmat(transpose(octaves), spec.nFilters_per_octave))
+    return (γs, χs, js)
 end

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -7,8 +7,14 @@ abstract Abstract2DSpec{T<:Number} <: AbstractSpec
 # Littlewood-Paley inequality. See documentation for details.
 function checkspec(ɛ, log2_length, max_qualityfactor,
     nFilters_per_octave, nOctaves)
-    if ɛ>=oftype(ɛ, 1.0)
+    if ɛ>=one(ɛ) || ɛ<zero(ɛ)
         error("ɛ should be in [0.0, 1.0[. A typical value is 1e-4.")
+    end
+    if log2_length<2
+        error("log2_length cannot be lower than 2.")
+    end
+    if nOctaves<1
+        error("nOctaves cannot be lower than 1.")
     end
     if (log2_length-nOctaves)<2
         error("Wavelet support is too large in low frequencies.\n",
@@ -17,7 +23,7 @@ function checkspec(ɛ, log2_length, max_qualityfactor,
         "nOctaves = ", nOctaves, "\n",
         "The gap should be at least 2.")
     end
-    if (log2_length-nOctaves)<log2(nFilters_per_octave)-1
+    if (log2_length-nOctaves) < (1+log2(nFilters_per_octave))
         error("Too many filters per octave for the given length.\n",
         "Either increase log2_length, decrease nOctaves, ",
         "or decrease nFilters_per_octave.\n",

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -9,7 +9,7 @@ support, and Littlewood-Paley inequality.
 
 * The truncation threshold ɛ must be in [0.0, 1.0[.
 
-* The signal length must be a power of two above 4.
+* The signal length must be a finite power of two above 4.
 
 * The maximum required quality factor must be between 1.0 and the number of
 filters per octaves.
@@ -30,6 +30,9 @@ function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
         error("Too short signal length.\n",
         "log2_length = ", log2_length, "\n",
         "log2_length must be ≧2")
+    end
+    if isinf(log2_length)
+        error("Signal length must be finite.\n log2_length = ", log2_length)
     end
     if nOctaves < 1
         error("Too few octaves.\n",

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -6,10 +6,10 @@ abstract Abstract2DSpec{T<:Number} <: AbstractSpec
 # checkspec enforces properties of the wavelets to satisfy null mean and
 # Littlewood-Paley inequality. See documentation for details.
 function checkspec(max_qualityfactor, nFilters_per_octave)
-  max_qualityfactor<1.0 || error("max_qualityfactor cannot be lower than 1.0.")
-  nFilters_per_octave<1 || error("nFilters_per_octave cannot be lower than 1.")
-  qualityfactor>nFilters_per_octave ||
-      error("max_qualityfactor cannot be lower than nFilters_per_octave")
+  max_qualityfactor>=1.0 || error("max_qualityfactor cannot be lower than 1.0.")
+  nFilters_per_octave>=1 || error("nFilters_per_octave cannot be lower than 1.")
+  max_qualityfactor<nFilters_per_octave ||
+      error("max_qualityfactor cannot be greater than nFilters_per_octave")
 end
 
 # realtype provides the type parameter of a complex type e.g. Complex{Float32}.

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -1,15 +1,22 @@
-# A Spec object contains the immutable specifications of a filter bank
+"""An AbstractSpec object contains all the immutable specifications in a
+wavelet filter bank"""
 abstract AbstractSpec
 abstract Abstract1DSpec{T<:Number} <: AbstractSpec
 abstract Abstract2DSpec{T<:Number} <: AbstractSpec
 
-# checkspec enforces properties of the wavelets to satisfy null mean and
-# Littlewood-Paley inequality. See documentation for details.
+"""Enforces properties of the wavelets to satisfy null mean, limited spatial
+support, and Littlewood-Paley inequality.
+* The truncation threshold ɛ must be in [0.0, 1.0[.
+* The signal length must be a power of two above 4.
+* The maximum required quality factor must be between 1.0 and the number of
+  filters per octaves.
+* The maximum scale must be at least 5 times above the maximum quality factor.
+* The lowest center frequency must be higher than 1, i.e. log2_length>nOctaves.
+* The lowest center frequency must be higher than half the number of filters
+  per octaves, i.e. (log2_length-nOctaves) >= log2(nFilters_per_octave).
+"""
 function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
   nFilters_per_octave, nOctaves)
-    if isinf(ɛ)
-      error("ɛ must be finite. A typical value is 1e-4.")
-    end
     if ɛ>=one(ɛ) || ɛ<zero(ɛ)
         error("ɛ must be in [0.0, 1.0[. A typical value is 1e-4.")
     end
@@ -38,9 +45,6 @@ function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
         """The inequality log2_length-nOctaves > log2(nFilters_per_octave)
         must be satisfied. Either increase log2_length, decrease nOctaves,
         or decrease nFilters_per_octave.""")
-    end
-    if isinf(max_qualityfactor)
-        error("max_qualityfactor must be finite.")
     end
     if max_qualityfactor < 1.0
         error("Too small maximum quality factor.\n",

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -8,7 +8,7 @@ abstract Abstract2DSpec{T<:Number} <: AbstractSpec
 function checkspec(max_qualityfactor, nFilters_per_octave)
   max_qualityfactor>=1.0 || error("max_qualityfactor cannot be lower than 1.0.")
   nFilters_per_octave>=1 || error("nFilters_per_octave cannot be lower than 1.")
-  max_qualityfactor<nFilters_per_octave ||
+  max_qualityfactor<=oftype(max_qualityfactor, nFilters_per_octave) ||
       error("max_qualityfactor cannot be greater than nFilters_per_octave")
 end
 

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -5,28 +5,37 @@ abstract Abstract2DSpec{T<:Number} <: AbstractSpec
 
 # checkspec enforces properties of the wavelets to satisfy null mean and
 # Littlewood-Paley inequality. See documentation for details.
-function checkspec(log2_length, max_qualityfactor, nFilters_per_octave, nOctaves)
-  if (log2_length-nOctaves)<2
-      error("Wavelet support is too large in low frequencies.\n",
-      "Either increase log2_length or decrease nOctaves.\n",
-      "log2_length = ", log2_length, "\n",
-      "nOctaves = ", nOctaves, "\n",
-      "The gap should be at least 2.")
-  end
-  if (log2_length-nOctaves)<log2(nFilters_per_octave)-1
-    error("Too many filters per octave for the given length.\n",
-    "Either increase log2_length, decrease nOctaves, ",
-    "or decrease nFilters_per_octave.\n",
-    "log2_length = ", log2_length, "\n",
-    "log2(nFilters_per_octave) = ", log2(nFilters_per_octave), "\n",
-    "nOctaves = ", nOctaves, ".\n"
-    "The inequality log2_length-nOctaves>log2(nFilters_per_octave) should ",
-    "be satisfied.")
-  end
-  max_qualityfactor>=1.0 || error("max_qualityfactor cannot be lower than 1.0.")
-  nFilters_per_octave>=1 || error("nFilters_per_octave cannot be lower than 1.")
-  max_qualityfactor<=oftype(max_qualityfactor, nFilters_per_octave) ||
-      error("max_qualityfactor cannot be greater than nFilters_per_octave")
+function checkspec(ɛ, log2_length, max_qualityfactor,
+    nFilters_per_octave, nOctaves)
+    if ɛ>=oftype(ɛ, 1.0)
+        error("ɛ should be in [0.0, 1.0[. A typical value is 1e-4.")
+    end
+    if (log2_length-nOctaves)<2
+        error("Wavelet support is too large in low frequencies.\n",
+        "Either increase log2_length or decrease nOctaves.\n",
+        "log2_length = ", log2_length, "\n",
+        "nOctaves = ", nOctaves, "\n",
+        "The gap should be at least 2.")
+    end
+    if (log2_length-nOctaves)<log2(nFilters_per_octave)-1
+        error("Too many filters per octave for the given length.\n",
+        "Either increase log2_length, decrease nOctaves, ",
+        "or decrease nFilters_per_octave.\n",
+        "log2_length = ", log2_length, "\n",
+        "log2(nFilters_per_octave) = ", log2(nFilters_per_octave), "\n",
+        "nOctaves = ", nOctaves, ".\n"
+        "The inequality log2_length-nOctaves > log2(nFilters_per_octave) ",
+        "should be satisfied.")
+    end
+    if max_qualityfactor<1.0
+        error("max_qualityfactor cannot be lower than 1.0.")
+    end
+    if nFilters_per_octave<1
+        error("nFilters_per_octave cannot be lower than 1.")
+    end
+    if max_qualityfactor>oftype(max_qualityfactor, nFilters_per_octave)
+        error("max_qualityfactor cannot be greater than nFilters_per_octave")
+    end
 end
 
 # realtype provides the type parameter of a complex type e.g. Complex{Float32}.
@@ -36,11 +45,11 @@ realtype{T<:Real}(::Type{Complex{T}}) = T
 
 # specgammas yields log-scales γs, chromas χs, and octaves js of a given spec.
 function specgammas(spec::AbstractSpec)
-    nΓs = spec.nFilters_per_octave * spec.nOctaves
-    γs = collect(0:(nΓs-1))
-    chromas = collect(0:(spec.nFilters_per_octave-1))
-    χs = repmat(chromas, spec.nOctaves)
-    octaves = collect(0:(spec.nOctaves-1))
-    js = vec(repmat(transpose(octaves), spec.nFilters_per_octave))
-    return (γs, χs, js)
+  nΓs = spec.nFilters_per_octave * spec.nOctaves
+  γs = collect(0:(nΓs-1))
+  chromas = collect(0:(spec.nFilters_per_octave-1))
+  χs = repmat(chromas, spec.nOctaves)
+  octaves = collect(0:(spec.nOctaves-1))
+  js = vec(repmat(transpose(octaves), spec.nFilters_per_octave))
+  return (γs, χs, js)
 end

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -30,7 +30,7 @@ function checkspec(ɛ, log2_length, max_qualityfactor, max_scale,
         "nOctaves = ", nOctaves, "\n",
         "The difference (log2_length-nOctaves) must be ≧2.")
     end
-    if (log2_length-nOctaves) < 1+floor(log2(nFilters_per_octave))
+    if (log2_length-nOctaves) < 1+log2(nFilters_per_octave)
         error("Too many filters per octave for the given length.\n",
         "log2_length = ", log2_length, "\n",
         "log2(nFilters_per_octave) = ", log2(nFilters_per_octave), "\n",

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -23,6 +23,7 @@ VariableTree{V}(value::V) =
     VariableTree(value, Dict{Symbol, Vector{VariableTree{V}}}())
 
 # A VariableTree leaf can be read/written with a VariableKey accessor
+import Base.getindex, Base.setindex!
 getindex(t::VariableTree, key::Nil) = t.value
 getindex(t::VariableTree, key::Cons) =
     getindex(t.symbols[key.head.symbol][key.head.level], key.tail)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,2 @@
 julia 0.3
 DataStructures 0.3.11
-Options 0.2.4

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.3
-Compat 0.4.10
 DataStructures 0.3.11
 Options 0.2.4

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -1,7 +1,7 @@
 import WaveletScattering: Morlet1DSpec, default_epsilon, localize
 
 numerictypes = [Float16, Float32, Float64,
-    Complex{Float16}, Complex{Float32}, Complex{Float64}]
+                Complex{Float16}, Complex{Float32}, Complex{Float64}]
 
 # Morlet1DSpec default options
 for T in numerictypes
@@ -49,7 +49,7 @@ for T in [Float16, Float32, Float64], nfo in nfos,
   max_q in 1:nfo, max_s in [exp2(11:16); Inf]
     machine_precision = max(1e-10, default_epsilon(T))
     spec = Morlet1DSpec(T, max_qualityfactor=max_q, max_scale=max_s,
-        nFilters_per_octave=nfo)
+                        nFilters_per_octave=nfo)
     (bandwidths, centerfrequencies, qualityfactors, scales) = localize(spec)
     @test all(qualityfactors.>=1.0)
     @test all(qualityfactors.<=max_q)

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -22,7 +22,7 @@ end
 
 # Morlet1DSpec default options
 for T in numerictypes
-  opts = @options
+  opts = @options signaltype = T
   RealT = realtype(T)
   spec = Morlet1DSpec(opts)
   @test spec.ɛ == eps(RealT)

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -54,8 +54,8 @@ for T in [Float16, Float32, Float64], nfo in nfos,
     @test all(qualityfactors.>=1.0)
     @test all(qualityfactors.<=max_q)
     @test all(scales.>0.0)
-    @test all(scales[qualityfactors.>1.0].< (max_s+machine_precision))
-    @test all(scales.< (exp2(spec.log2_length)+machine_precision))
+    @test all(scales[qualityfactors.>1.0] .< (max_s+machine_precision))
+    @test all(scales .< (exp2(spec.log2_length)+machine_precision))
     resolutions = centerfrequencies / centerfrequencies[1]
     @test_approx_eq_eps bandwidths resolutions./qualityfactors eps(T)
     heisenberg_tradeoff = bandwidths .* scales

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -38,7 +38,7 @@ for T in numerictypes
   # max_qualityfactor defaults to nFilters_per_octave when it is provided
   spec = Morlet1DSpec(@options nFilters_per_octave=12)
   @test_approx_eq spec.max_qualityfactor 12.0
-  @test spec.nOctaves == 9
+  @test spec.nOctaves == 10
 end
 
 # Zero-argument constructor

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -1,6 +1,6 @@
-import WaveletScattering: Morlet1D, realtype
+import WaveletScattering: Morlet1DSpec, realtype
 
-# Morlet1D constructor
+# Morlet1DSpec constructor
 for signaltype in [Float16, Float32, Float64,
                    Complex{Float16}, Complex{Float32}, Complex{Float64}]
     RealT = realtype(signaltype)

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -14,7 +14,7 @@ for T in numerictypes
   @test spec.nFilters_per_octave == 1
   @test spec.nOctaves == 8
   # nFilters_per_octave defaults to max_qualityfactor when it is provided
-  spec = Morlet1DSpec(nFilters_per_octave = 8)
+  spec = Morlet1DSpec(nFilters_per_octave=8)
   @test spec.nFilters_per_octave == 8
   @test spec.nOctaves == 10
   # max_qualityfactor defaults to nFilters_per_octave when it is provided
@@ -56,7 +56,7 @@ for T in [Float16, Float32, Float64], nfo in nfos,
     @test all(scales.>0.0)
     @test all(scales[qualityfactors.>1.0].< (max_s+machine_precision))
     @test all(scales.< (exp2(spec.log2_length)+machine_precision))
-    # TODO @test scales[end] > (0.5 * exp2(spec.log2_length))
+    @show(scales[end],(0.5 * exp2(spec.log2_length)))
     resolutions = centerfrequencies / centerfrequencies[1]
     @test_approx_eq_eps bandwidths resolutions./qualityfactors eps(T)
     heisenberg_tradeoff = bandwidths .* scales

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -35,12 +35,6 @@ for T in numerictypes
   spec = Morlet1DSpec(@options max_qualityfactor=8.0)
   @test spec.nFilters_per_octave == 8
   @test spec.nOctaves == 11
-=======
-  @test spec.nOctaves == 8
-  # nFilters_per_octave defaults to max_qualityfactor when it is provided
-  spec = Morlet1DSpec(@options max_qualityfactor=8.0)
-  @test spec.nFilters_per_octave == 8
->>>>>>> morlet-localize
   # max_qualityfactor defaults to nFilters_per_octave when it is provided
   spec = Morlet1DSpec(@options nFilters_per_octave=12)
   @test_approx_eq spec.max_qualityfactor 12.0
@@ -49,11 +43,7 @@ end
 
 # Zero-argument constructor
 spec = Morlet1DSpec()
-<<<<<<< HEAD
 @test spec.nOctaves == spec.log2_length - 1
-=======
-@test spec.nOctaves == spec.log2_length
->>>>>>> morlet-localize
 
 # localize
 # in the dyadic case, check that the mother center center frequency is 0.39
@@ -72,7 +62,6 @@ for n in [2, 4, 8, 12, 16, 24, 32]
     @test all(centerfreqs.>0.0)
 end
 for RealT in [Float16, Float32, Float64]
-<<<<<<< HEAD
     for max_q in [1, 2, 4, 8, 12, 16, 24, 32], max_s in [exp2(11:16); Inf]
         opts = @options signaltype=RealT max_qualityfactor=max_q max_scale=max_s
         spec = Morlet1DSpec(opts)
@@ -88,23 +77,4 @@ for RealT in [Float16, Float32, Float64]
         @test all(abs(diff(heisenberg_tradeoff)) .< 10.0*eps(RealT))
         # TODO: test bandwidths and scales on actual wavelets
     end
-=======
-for max_q in [1, 2, 4, 8, 12, 16, 24, 32]
-  for max_s in [exp2(11:16); Inf]
-      opts = @options signaltype=RealT max_qualityfactor=max_q max_scale=max_s
-      spec = Morlet1DSpec(opts)
-      (bandwidths, centerfrequencies, qualityfactors, scales) = localize(spec)
-      @test all(qualityfactors.>=1.0)
-      @test all(qualityfactors.<=max_q)
-      @test all(scales.>0.0)
-      @test all(scales.<=max_s)
-      resolutions = centerfrequencies / centerfrequencies[1]
-      @test_approx_eq_eps bandwidths resolutions./qualityfactors eps(RealT)
-      heisenberg_tradeoff = bandwidths .* scales
-      nWavelets = length(heisenberg_tradeoff)
-      @test all(abs(diff(heisenberg_tradeoff)) .< 10.0*eps(RealT))
-      # TODO: test bandwidths and scales on actual wavelets
-  end
-end
->>>>>>> morlet-localize
 end

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -23,7 +23,7 @@ end
 # Morlet1DSpec default options
 for T in numerictypes
   RealT = realtype(T)
-  # nOctaves no longers defaults to log2_length when specified by user
+  # ordinary defaults, user-specified nOctaves
   spec = Morlet1DSpec(@options signaltype=T nOctaves=8)
   @test spec.ɛ == eps(RealT)
   @test spec.log2_length == 15
@@ -43,7 +43,7 @@ end
 
 # Zero-argument constructor
 spec = Morlet1DSpec()
-@test spec.nOctaves == spec.log2_length - 1
+@test spec.nOctaves == spec.log2_length - 2
 
 # localize
 # in the dyadic case, check that the mother center center frequency is 0.39

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -3,16 +3,6 @@ import WaveletScattering: Morlet1DSpec, default_epsilon, localize
 numerictypes = [Float16, Float32, Float64,
     Complex{Float16}, Complex{Float32}, Complex{Float64}]
 
-# Morlet1DSpec constructor
-for T in numerictypes
-    spec = Morlet1DSpec{T}(T, ɛ=1e-5, log2_length=15, max_qualityfactor=8.0,
-        max_scale=1e4, nFilters_per_octave=12, nOctaves=8)
-    @test isa(spec.ɛ, Type(T))
-    @test spec.signaltype == T
-    @test isa(spec.max_qualityfactor, Float64)
-    @test isa(spec.max_scale, Float64)
-end
-
 # Morlet1DSpec default options
 for T in numerictypes
   # ordinary defaults, user-specified nOctaves

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -1,16 +1,16 @@
 import WaveletScattering: Morlet1DSpec, realtype
 
 # Morlet1DSpec constructor
-for signaltype in [Float16, Float32, Float64,
+for T in [Float16, Float32, Float64,
                    Complex{Float16}, Complex{Float32}, Complex{Float64}]
-    RealT = realtype(signaltype)
+    RealT = realtype(T)
     ɛ = 1e-5
     log2_length = 15
     max_qualityfactor = 8.0
     max_scale = 10000.0
     nFilters_per_octave = 12
     nOctaves = 8
-    m = Morlet1DSpec(ɛ, signaltype, log2_length, max_qualityfactor, max_scale,
+    m = Morlet1DSpec{T}(ɛ, T, log2_length, max_qualityfactor, max_scale,
         nFilters_per_octave, nOctaves)
     @test isa(m.ɛ, RealT)
     @test m.signaltype == signaltype

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -69,11 +69,11 @@ for RealT in [Float16, Float32, Float64]
         @test all(qualityfactors.>=1.0)
         @test all(qualityfactors.<=max_q)
         @test all(scales.>0.0)
-        @test all(scales.<=max_s)
+        @test all(scales[qualityfactors.>1.0].<=max_s)
+        @test all(scales.<=exp2(log2_length))
         resolutions = centerfrequencies / centerfrequencies[1]
         @test_approx_eq_eps bandwidths resolutions./qualityfactors eps(RealT)
         heisenberg_tradeoff = bandwidths .* scales
-        nWavelets = length(heisenberg_tradeoff)
         @test all(abs(diff(heisenberg_tradeoff)) .< 10.0*eps(RealT))
         # TODO: test bandwidths and scales on actual wavelets
     end

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -34,11 +34,11 @@ for T in numerictypes
   # nFilters_per_octave defaults to max_qualityfactor when it is provided
   spec = Morlet1DSpec(@options max_qualityfactor=8.0)
   @test spec.nFilters_per_octave == 8
-  @test spec.nOctaves == 10
+  @test spec.nOctaves == 9
   # max_qualityfactor defaults to nFilters_per_octave when it is provided
   spec = Morlet1DSpec(@options nFilters_per_octave=12)
   @test_approx_eq spec.max_qualityfactor 12.0
-  @test spec.nOctaves == 10
+  @test spec.nOctaves == 9
 end
 
 # Zero-argument constructor

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -70,7 +70,7 @@ for RealT in [Float16, Float32, Float64]
         @test all(qualityfactors.<=max_q)
         @test all(scales.>0.0)
         @test all(scales[qualityfactors.>1.0].< (max_s+eps(RealT)) )
-        @test all(scales.< exp2(spec.log2_length))
+        @test all(scales.< (exp2(spec.log2_length)+eps(RealT)))
         resolutions = centerfrequencies / centerfrequencies[1]
         @test_approx_eq_eps bandwidths resolutions./qualityfactors eps(RealT)
         heisenberg_tradeoff = bandwidths .* scales

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -1,3 +1,5 @@
+import WaveletScattering: Morlet1D, realtype
+
 # Morlet1D constructor
 for signaltype in [Float16, Float32, Float64,
                    Complex{Float16}, Complex{Float32}, Complex{Float64}]

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -16,8 +16,8 @@ for T in numerictypes
         nFilters_per_octave, nOctaves, T)
     @test isa(spec.ɛ, RealT)
     @test spec.signaltype == T
-    @test isa(spec.max_qualityfactor, RealT)
-    @test isa(spec.max_scale, RealT)
+    @test isa(spec.max_qualityfactor, Float64)
+    @test isa(spec.max_scale, Float64)
 end
 
 # Morlet1DSpec default options
@@ -69,7 +69,7 @@ for RealT in [Float16, Float32, Float64]
         @test all(qualityfactors.>=1.0)
         @test all(qualityfactors.<=max_q)
         @test all(scales.>0.0)
-        @test all(scales[qualityfactors.>1.0].< (max_s+eps(RealT)) )
+        @test all(scales[qualityfactors.>1.0].< (max_s+eps(RealT)))
         @test all(scales.< (exp2(spec.log2_length)+eps(RealT)))
         resolutions = centerfrequencies / centerfrequencies[1]
         @test_approx_eq_eps bandwidths resolutions./qualityfactors eps(RealT)

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -34,11 +34,11 @@ for T in numerictypes
   # nFilters_per_octave defaults to max_qualityfactor when it is provided
   spec = Morlet1DSpec(@options max_qualityfactor=8.0)
   @test spec.nFilters_per_octave == 8
-  @test spec.nOctaves == 11
+  @test spec.nOctaves == 10
   # max_qualityfactor defaults to nFilters_per_octave when it is provided
   spec = Morlet1DSpec(@options nFilters_per_octave=12)
   @test_approx_eq spec.max_qualityfactor 12.0
-  @test spec.nOctaves == 10
+  @test spec.nOctaves == 9
 end
 
 # Zero-argument constructor

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -22,7 +22,7 @@ end
 
 # Morlet1DSpec default options
 for T in numerictypes
-  opts = @options signaltype = T
+  opts = @options signaltype=T nOctaves=8
   RealT = realtype(T)
   spec = Morlet1DSpec(opts)
   @test spec.ɛ == eps(RealT)
@@ -38,3 +38,7 @@ for T in numerictypes
   spec = Morlet1DSpec(opts)
   @test_approx_eq spec.max_qualityfactor 12.0
 end
+
+# Zero-argument constructor
+spec = Morlet1DSpec()
+@test spec.nOctaves == spec.log2_length

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -28,7 +28,7 @@ for T in numerictypes
   @test spec.ɛ == eps(RealT)
   @test spec.log2_length == 15
   @test_approx_eq spec.max_qualityfactor 1.0
-  @test_approx_eq spec.max_scale Inf
+  @test_approx_eq spec.max_scale 1<<log2_length
   @test spec.nFilters_per_octave == 1
   @test spec.nOctaves == 8
   # nFilters_per_octave defaults to max_qualityfactor when it is provided

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -69,8 +69,8 @@ for RealT in [Float16, Float32, Float64]
         @test all(qualityfactors.>=1.0)
         @test all(qualityfactors.<=max_q)
         @test all(scales.>0.0)
-        @test all(scales[qualityfactors.>1.0].<=max_s)
-        @test all(scales.<=exp2(log2_length))
+        @test all(scales[qualityfactors.>1.0].< (max_s+eps(RealT)) )
+        @test all(scales.< exp2(spec.log2_length))
         resolutions = centerfrequencies / centerfrequencies[1]
         @test_approx_eq_eps bandwidths resolutions./qualityfactors eps(RealT)
         heisenberg_tradeoff = bandwidths .* scales

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -27,14 +27,14 @@ for T in numerictypes
   spec = Morlet1DSpec(opts)
   @test spec.ɛ == eps(RealT)
   @test spec.log2_length == 15
-  @test_approx_eq spec.max_qualityfactor == 1.0
-  @test_approx_eq spec.max_scale == Inf
-  @test spec.max_nFilters_per_octave == 1
+  @test_approx_eq spec.max_qualityfactor 1.0
+  @test_approx_eq spec.max_scale Inf
+  @test spec.nFilters_per_octave == 1
   @test spec.nOctaves == 8
   opts = @options max_qualityfactor=8.0
   spec = Morlet1DSpec(opts)
-  @test spec.max_nFilters_per_octave == 8
-  spec = Morlet1DSpec(opts)
+  @test spec.nFilters_per_octave == 8
   opts = @options nFilters_per_octave=12
-  @test_approx_eq spec.max_qualityfactor == 12.0
+  spec = Morlet1DSpec(opts)
+  @test_approx_eq spec.max_qualityfactor 12.0
 end

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -26,15 +26,15 @@ for T in numerictypes
   RealT = realtype(T)
   spec = Morlet1DSpec(opts)
   @test spec.ɛ == eps(RealT)
-  @test spec.log2_length = 15
+  @test spec.log2_length == 15
   @test_approx_eq spec.max_qualityfactor == 1.0
   @test_approx_eq spec.max_scale == Inf
   @test spec.max_nFilters_per_octave == 1
   @test spec.nOctaves == 8
-  opts = @options max_qualityfactor = 8.0
+  opts = @options max_qualityfactor=8.0
   spec = Morlet1DSpec(opts)
   @test spec.max_nFilters_per_octave == 8
   spec = Morlet1DSpec(opts)
-  opts = @options nFilters_per_octave = 12
+  opts = @options nFilters_per_octave=12
   @test_approx_eq spec.max_qualityfactor == 12.0
 end

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -56,7 +56,6 @@ for T in [Float16, Float32, Float64], nfo in nfos,
     @test all(scales.>0.0)
     @test all(scales[qualityfactors.>1.0].< (max_s+machine_precision))
     @test all(scales.< (exp2(spec.log2_length)+machine_precision))
-    @show(scales[end],(0.5 * exp2(spec.log2_length)))
     resolutions = centerfrequencies / centerfrequencies[1]
     @test_approx_eq_eps bandwidths resolutions./qualityfactors eps(T)
     heisenberg_tradeoff = bandwidths .* scales

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -12,8 +12,8 @@ for T in numerictypes
     max_scale = 10000.0
     nFilters_per_octave = 12
     nOctaves = 8
-    spec = Morlet1DSpec{T}(ɛ, T, log2_length, max_qualityfactor, max_scale,
-        nFilters_per_octave, nOctaves)
+    spec = Morlet1DSpec{T}(ɛ, log2_length, max_qualityfactor, max_scale,
+        nFilters_per_octave, nOctaves, T)
     @test isa(spec.ɛ, RealT)
     @test spec.signaltype == T
     @test isa(spec.max_qualityfactor, RealT)

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -5,16 +5,9 @@ numerictypes = [Float16, Float32, Float64,
 
 # Morlet1DSpec constructor
 for T in numerictypes
-    RealT = realtype(T)
-    ɛ = 1e-5
-    log2_length = 15
-    max_qualityfactor = 8.0
-    max_scale = 10000.0
-    nFilters_per_octave = 12
-    nOctaves = 8
-    spec = Morlet1DSpec{T}(ɛ, log2_length, max_qualityfactor, max_scale,
-        nFilters_per_octave, nOctaves, T)
-    @test isa(spec.ɛ, RealT)
+    spec = Morlet1DSpec{T}(T, ɛ=1e-5, log2_length=15, max_qualityfactor=8.0,
+        max_scale=1e4, nFilters_per_octave=12, nOctaves=8)
+    @test isa(spec.ɛ, realtype(T))
     @test spec.signaltype == T
     @test isa(spec.max_qualityfactor, Float64)
     @test isa(spec.max_scale, Float64)
@@ -24,7 +17,7 @@ end
 for T in numerictypes
   RealT = realtype(T)
   # ordinary defaults, user-specified nOctaves
-  spec = Morlet1DSpec(@options signaltype=T nOctaves=8)
+  spec = Morlet1DSpec(signaltype=T, nOctaves=8)
   @test spec.ɛ == eps(RealT)
   @test spec.log2_length == 15
   @test_approx_eq spec.max_qualityfactor 1.0
@@ -32,11 +25,11 @@ for T in numerictypes
   @test spec.nFilters_per_octave == 1
   @test spec.nOctaves == 8
   # nFilters_per_octave defaults to max_qualityfactor when it is provided
-  spec = Morlet1DSpec(@options max_qualityfactor=8.0)
+  spec = Morlet1DSpec(max_qualityfactor=8.0)
   @test spec.nFilters_per_octave == 8
   @test spec.nOctaves == 10
   # max_qualityfactor defaults to nFilters_per_octave when it is provided
-  spec = Morlet1DSpec(@options nFilters_per_octave=12)
+  spec = Morlet1DSpec(nFilters_per_octave=12)
   @test_approx_eq spec.max_qualityfactor 12.0
   @test spec.nOctaves == 9
 end
@@ -47,12 +40,12 @@ spec = Morlet1DSpec()
 
 # localize
 # in the dyadic case, check that the mother center center frequency is 0.39
-spec = Morlet1DSpec(@options nFilters_per_octave=1)
+spec = Morlet1DSpec(nFilters_per_octave=1)
 (bandwidths, centerfrequencies, qualityfactors, scales) = localize(spec)
 @test_approx_eq centerfrequencies[1] 0.39
 nfos = [2, 4, 8, 12, 16, 24, 32]
 for nfo in nfos[2:end]
-    spec = Morlet1DSpec(@options nFilters_per_octave=nfo)
+    spec = Morlet1DSpec(nFilters_per_octave=nfo)
     # check that the mother center frequency is at the right place
     (bandwidths, centerfreqs, qualityfactors, scales) = localize(spec)
     @test_approx_eq (centerfreqs[1]-centerfreqs[2]) (1.0 - 2*centerfreqs[1])
@@ -65,12 +58,8 @@ end
 for RealT in [Float16, Float32, Float64], nfo in nfos,
   max_q in 1:nfo, max_s in [exp2(11:16); Inf]
     machine_precision = max(1e-10, eps(RealT))
-    opts = @options begin
-      signaltype=RealT
-      max_qualityfactor=max_q
-      max_scale=max_s
-      nFilters_per_octave=nfo end
-    spec = Morlet1DSpec(opts)
+    spec = Morlet1DSpec(max_qualityfactor=max_q, max_scale=max_s,
+        nFilters_per_octave=nfo, signaltype=RealT)
     (bandwidths, centerfrequencies, qualityfactors, scales) = localize(spec)
     ten_epsilon = 10.0*eps(RealT)
     @test all(qualityfactors.>=1.0)

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -1,8 +1,7 @@
 import WaveletScattering: Morlet1DSpec, realtype
 
 # Morlet1DSpec constructor
-for T in [Float16, Float32, Float64,
-                   Complex{Float16}, Complex{Float32}, Complex{Float64}]
+for T in [Float16, Float32, Float64, Complex{Float16}, Complex{Float32}, Complex{Float64}]
     RealT = realtype(T)
     ɛ = 1e-5
     log2_length = 15
@@ -13,7 +12,7 @@ for T in [Float16, Float32, Float64,
     m = Morlet1DSpec{T}(ɛ, T, log2_length, max_qualityfactor, max_scale,
         nFilters_per_octave, nOctaves)
     @test isa(m.ɛ, RealT)
-    @test m.signaltype == signaltype
+    @test m.signaltype == T
     @test isa(max_qualityfactor, RealT)
     @test isa(max_scale, RealT)
 end

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -35,6 +35,12 @@ for T in numerictypes
   spec = Morlet1DSpec(@options max_qualityfactor=8.0)
   @test spec.nFilters_per_octave == 8
   @test spec.nOctaves == 11
+=======
+  @test spec.nOctaves == 8
+  # nFilters_per_octave defaults to max_qualityfactor when it is provided
+  spec = Morlet1DSpec(@options max_qualityfactor=8.0)
+  @test spec.nFilters_per_octave == 8
+>>>>>>> morlet-localize
   # max_qualityfactor defaults to nFilters_per_octave when it is provided
   spec = Morlet1DSpec(@options nFilters_per_octave=12)
   @test_approx_eq spec.max_qualityfactor 12.0
@@ -43,7 +49,11 @@ end
 
 # Zero-argument constructor
 spec = Morlet1DSpec()
+<<<<<<< HEAD
 @test spec.nOctaves == spec.log2_length - 1
+=======
+@test spec.nOctaves == spec.log2_length
+>>>>>>> morlet-localize
 
 # localize
 # in the dyadic case, check that the mother center center frequency is 0.39
@@ -62,6 +72,7 @@ for n in [2, 4, 8, 12, 16, 24, 32]
     @test all(centerfreqs.>0.0)
 end
 for RealT in [Float16, Float32, Float64]
+<<<<<<< HEAD
     for max_q in [1, 2, 4, 8, 12, 16, 24, 32], max_s in [exp2(11:16); Inf]
         opts = @options signaltype=RealT max_qualityfactor=max_q max_scale=max_s
         spec = Morlet1DSpec(opts)
@@ -77,4 +88,23 @@ for RealT in [Float16, Float32, Float64]
         @test all(abs(diff(heisenberg_tradeoff)) .< 10.0*eps(RealT))
         # TODO: test bandwidths and scales on actual wavelets
     end
+=======
+for max_q in [1, 2, 4, 8, 12, 16, 24, 32]
+  for max_s in [exp2(11:16); Inf]
+      opts = @options signaltype=RealT max_qualityfactor=max_q max_scale=max_s
+      spec = Morlet1DSpec(opts)
+      (bandwidths, centerfrequencies, qualityfactors, scales) = localize(spec)
+      @test all(qualityfactors.>=1.0)
+      @test all(qualityfactors.<=max_q)
+      @test all(scales.>0.0)
+      @test all(scales.<=max_s)
+      resolutions = centerfrequencies / centerfrequencies[1]
+      @test_approx_eq_eps bandwidths resolutions./qualityfactors eps(RealT)
+      heisenberg_tradeoff = bandwidths .* scales
+      nWavelets = length(heisenberg_tradeoff)
+      @test all(abs(diff(heisenberg_tradeoff)) .< 10.0*eps(RealT))
+      # TODO: test bandwidths and scales on actual wavelets
+  end
+end
+>>>>>>> morlet-localize
 end

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -1,0 +1,17 @@
+# Morlet1D constructor
+for signaltype in [Float16, Float32, Float64,
+                   Complex{Float16}, Complex{Float32}, Complex{Float64}]
+    RealT = realtype(signaltype)
+    ɛ = 1e-5
+    log2_length = 15
+    max_qualityfactor = 8.0
+    max_scale = 10000.0
+    nFilters_per_octave = 12
+    nOctaves = 8
+    m = Morlet1DSpec(ɛ, signaltype, log2_length, max_qualityfactor, max_scale,
+        nFilters_per_octave, nOctaves)
+    @test isa(m.ɛ, RealT)
+    @test m.signaltype == signaltype
+    @test isa(max_qualityfactor, RealT)
+    @test isa(max_scale, RealT)
+end

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -28,7 +28,7 @@ for T in numerictypes
   @test spec.ɛ == eps(RealT)
   @test spec.log2_length == 15
   @test_approx_eq spec.max_qualityfactor 1.0
-  @test_approx_eq spec.max_scale 1<<log2_length
+  @test_approx_eq spec.max_scale Inf
   @test spec.nFilters_per_octave == 1
   @test spec.nOctaves == 8
   # nFilters_per_octave defaults to max_qualityfactor when it is provided

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -34,7 +34,7 @@ for T in numerictypes
   # nFilters_per_octave defaults to max_qualityfactor when it is provided
   spec = Morlet1DSpec(@options max_qualityfactor=8.0)
   @test spec.nFilters_per_octave == 8
-  @test spec.nOctaves == 9
+  @test spec.nOctaves == 10
   # max_qualityfactor defaults to nFilters_per_octave when it is provided
   spec = Morlet1DSpec(@options nFilters_per_octave=12)
   @test_approx_eq spec.max_qualityfactor 12.0

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -1,4 +1,4 @@
-import WaveletScattering: Morlet1DSpec, realtype
+import WaveletScattering: Morlet1DSpec, localize, realtype
 
 numerictypes = [Float16, Float32, Float64,
     Complex{Float16}, Complex{Float32}, Complex{Float64}]

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -1,7 +1,10 @@
 import WaveletScattering: Morlet1DSpec, realtype
 
+numerictypes = [Float16, Float32, Float64,
+    Complex{Float16}, Complex{Float32}, Complex{Float64}]
+
 # Morlet1DSpec constructor
-for T in [Float16, Float32, Float64, Complex{Float16}, Complex{Float32}, Complex{Float64}]
+for T in numerictypes
     RealT = realtype(T)
     ɛ = 1e-5
     log2_length = 15
@@ -15,4 +18,23 @@ for T in [Float16, Float32, Float64, Complex{Float16}, Complex{Float32}, Complex
     @test spec.signaltype == T
     @test isa(spec.max_qualityfactor, RealT)
     @test isa(spec.max_scale, RealT)
+end
+
+# Morlet1DSpec default options
+for T in numerictypes
+  opts = @options
+  RealT = realtype(T)
+  spec = Morlet1DSpec(opts)
+  @test spec.ɛ == eps(RealT)
+  @test spec.log2_length = 15
+  @test_approx_eq spec.max_qualityfactor == 1.0
+  @test_approx_eq spec.max_scale == Inf
+  @test spec.max_nFilters_per_octave == 1
+  @test spec.nOctaves == 8
+  opts = @options max_qualityfactor = 8.0
+  spec = Morlet1DSpec(opts)
+  @test spec.max_nFilters_per_octave == 8
+  spec = Morlet1DSpec(opts)
+  opts = @options nFilters_per_octave = 12
+  @test_approx_eq spec.max_qualityfactor == 12.0
 end

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -6,7 +6,7 @@ numerictypes = [Float16, Float32, Float64,
 # Morlet1DSpec default options
 for T in numerictypes
   # ordinary defaults, user-specified nOctaves
-  spec = Morlet1DSpec(signaltype=T, nOctaves=8)
+  spec = Morlet1DSpec(T, nOctaves=8)
   @test spec.ɛ == default_epsilon(T)
   @test spec.log2_length == 15
   @test_approx_eq spec.max_qualityfactor 1.0
@@ -14,7 +14,7 @@ for T in numerictypes
   @test spec.nFilters_per_octave == 1
   @test spec.nOctaves == 8
   # nFilters_per_octave defaults to max_qualityfactor when it is provided
-  spec = Morlet1DSpec(max_qualityfactor=8.0)
+  spec = Morlet1DSpec(nFilters_per_octave = 8)
   @test spec.nFilters_per_octave == 8
   @test spec.nOctaves == 10
   # max_qualityfactor defaults to nFilters_per_octave when it is provided
@@ -25,6 +25,7 @@ end
 
 # Zero-argument constructor
 spec = Morlet1DSpec()
+@test spec.signaltype == Float32
 @test spec.nOctaves == spec.log2_length - 2
 
 # localize
@@ -47,8 +48,8 @@ end
 for T in [Float16, Float32, Float64], nfo in nfos,
   max_q in 1:nfo, max_s in [exp2(11:16); Inf]
     machine_precision = max(1e-10, default_epsilon(T))
-    spec = Morlet1DSpec(max_qualityfactor=max_q, max_scale=max_s,
-        nFilters_per_octave=nfo, signaltype=T)
+    spec = Morlet1DSpec(T, max_qualityfactor=max_q, max_scale=max_s,
+        nFilters_per_octave=nfo)
     (bandwidths, centerfrequencies, qualityfactors, scales) = localize(spec)
     @test all(qualityfactors.>=1.0)
     @test all(qualityfactors.<=max_q)

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -30,7 +30,7 @@ for T in numerictypes
   @test_approx_eq spec.max_qualityfactor 1.0
   @test_approx_eq spec.max_scale Inf
   @test spec.nFilters_per_octave == 1
-  @test spec.nOctaves == 14
+  @test spec.nOctaves == 8
   # nFilters_per_octave defaults to max_qualityfactor when it is provided
   spec = Morlet1DSpec(@options max_qualityfactor=8.0)
   @test spec.nFilters_per_octave == 8

--- a/test/morlet1d.jl
+++ b/test/morlet1d.jl
@@ -9,10 +9,10 @@ for T in [Float16, Float32, Float64, Complex{Float16}, Complex{Float32}, Complex
     max_scale = 10000.0
     nFilters_per_octave = 12
     nOctaves = 8
-    m = Morlet1DSpec{T}(ɛ, T, log2_length, max_qualityfactor, max_scale,
+    spec = Morlet1DSpec{T}(ɛ, T, log2_length, max_qualityfactor, max_scale,
         nFilters_per_octave, nOctaves)
-    @test isa(m.ɛ, RealT)
-    @test m.signaltype == T
-    @test isa(max_qualityfactor, RealT)
-    @test isa(max_scale, RealT)
+    @test isa(spec.ɛ, RealT)
+    @test spec.signaltype == T
+    @test isa(spec.max_qualityfactor, RealT)
+    @test isa(spec.max_scale, RealT)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using Base.Test
-using WaveletScattering
 
 tests = [
     "spec",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using Base.Test
 
+using DataStructures
+
 tests = [
     "spec",
     "variables"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,5 @@
 using Base.Test
 
-using DataStructures
-
 tests = [
     "spec",
     "variables"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Base.Test
 
 using DataStructures
+using OptionsMod
 
 tests = [
     "spec",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Base.Test
+using WaveletScattering
 
 tests = [
     "spec",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using DataStructures
 
 tests = [
     "spec",
+    "morlet1d",
     "variables"
 ]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,5 @@
 using Base.Test
 
-require("Options")
-
 using DataStructures
 using OptionsMod
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using Base.Test
 
+require("Options")
+
 using DataStructures
 using OptionsMod
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using Base.Test
 
 using DataStructures
-using OptionsMod
 
 tests = [
     "spec",

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -16,11 +16,11 @@ end
 @test Test2DSpec <: AbstractSpec
 
 # checkspec
-opts = @options max_qualityfactor=2.0 max_nFilters_per_octave=4
+opts = @options max_qualityfactor=2.0 nFilters_per_octave=4
 @test checkspec(opts) == nothing
-opts = @options max_qualityfactor=0.5 max_nFilters_per_octave=4
+opts = @options max_qualityfactor=0.5 nFilters_per_octave=4
 @test_throws ErrorException checkspec(opts)
-opts = @options max_qualityfactor=8.0 max_nFilters_per_octave=4
+opts = @options max_qualityfactor=8.0 nFilters_per_octave=4
 @test_throws ErrorException checkspec(opts)
 
 # realtype

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -16,13 +16,51 @@ end
 @test Test2DSpec <: AbstractSpec
 
 # checkspec
-max_qualityfactor = 2.0
-nFilters_per_octave = 4
-@test checkspec(max_qualityfactor, nFilters_per_octave)
-max_qualityfactor = 0.5
-@test_throws ErrorException checkspec(max_qualityfactor, nFilters_per_octave)
-max_qualityfactor = 8.0
-@test_throws ErrorException checkspec(max_qualityfactor, nFilters_per_octave)
+ɛ = eps(Float32)
+log2_length = 15
+max_qualityfactor = 12.0
+max_scale = 1e5
+nFilters_per_octave = 12
+nOctaves = 8
+# normal behavior
+@test checkspec(ɛ, log2_length, max_qualityfactor,
+    max_scale, nFilters_per_octave, nOctaves)
+# error if ɛ is infinite
+@test_throws ErrorException checkspec(Inf, log2_length, max_qualityfactor,
+    max_scale, nFilters_per_octave, nOctaves)
+# error if ɛ is strictly negative zero
+@test_throws ErrorException checkspec(-1.0, log2_length, max_qualityfactor,
+    max_scale, nFilters_per_octave, nOctaves)
+# error if ɛ equal or greater than one
+@test_throws ErrorException checkspec(1.0, log2_length, max_qualityfactor,
+    max_scale, nFilters_per_octave, nOctaves)
+# error if log2_length is smaller than 2
+@test_throws ErrorException checkspec(ɛ, 1, max_qualityfactor,
+    max_scale, nFilters_per_octave, nOctaves)
+# error if nOctaves is smaller than 1
+@test_throws ErrorException checkspec(ɛ, log2_length, max_qualityfactor,
+    max_scale, nFilters_per_octave, 0)
+# error if the difference (log2_length-nOctaves) is smaller than 2
+@test_throws ErrorException checkspec(ɛ, 9, max_qualityfactor,
+    max_scale, 1, 8)
+# error if log2_length-nOctaves <= log2(nFilters_per_octave)
+@test_throws ErrorException checkspec(ɛ, 12, max_qualityfactor,
+    max_scale, 32, 9)
+# error if max_qualityfactor is infinite
+@test_throws ErrorException checkspec(ɛ, log2_length, Inf,
+    max_scale, nFilters_per_octave, nOctaves)
+# error if max_qualityfactor is strictly smaller than 1.0
+@test_throws ErrorException checkspec(ɛ, log2_length, 0.9,
+    max_scale, nFilters_per_octave, nOctaves)
+# error if max_scale < (5.0*max_qualityfactor)
+@test_throws ErrorException checkspec(ɛ, log2_length, 32.0,
+    100.0, nFilters_per_octave, nOctaves)
+# error if nFilters_per_octave < 1
+@test_throws ErrorException checkspec(ɛ, log2_length, max_qualityfactor,
+    max_scale, 0, nOctaves)
+# error if max_qualityfactor > nFilters_per_octave
+@test_throws ErrorException checkspec(ɛ, log2_length, 8.0,
+    max_scale, 4, nOctaves)
 
 # realtype
 @test realtype(Float32) == Float32

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -18,7 +18,7 @@ end
 # checkspec
 max_qualityfactor = 2.0
 nFilters_per_octave = 4
-@test checkspec(max_qualityfactor, nFilters_per_octave) == nothing
+@test checkspec(max_qualityfactor, nFilters_per_octave)
 max_qualityfactor = 0.5
 @test_throws ErrorException checkspec(max_qualityfactor, nFilters_per_octave)
 max_qualityfactor = 8.0

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -11,9 +11,6 @@ nOctaves = 8
 # normal behavior
 @test checkspec(ɛ, log2_length, max_qualityfactor,
     max_scale, nFilters_per_octave, nOctaves)
-# error if ɛ is infinite
-@test_throws ErrorException checkspec(Inf, log2_length, max_qualityfactor,
-    max_scale, nFilters_per_octave, nOctaves)
 # error if ɛ is strictly negative zero
 @test_throws ErrorException checkspec(-1.0, log2_length, max_qualityfactor,
     max_scale, nFilters_per_octave, nOctaves)
@@ -32,9 +29,9 @@ nOctaves = 8
 # error if log2_length-nOctaves <= log2(nFilters_per_octave)
 @test_throws ErrorException checkspec(ɛ, 12, max_qualityfactor,
     max_scale, 32, 9)
-# error if max_qualityfactor is infinite
-@test_throws ErrorException checkspec(ɛ, log2_length, Inf,
-    max_scale, nFilters_per_octave, nOctaves)
+# error if max_qualityfactor > nFilters_per_octave
+@test_throws ErrorException checkspec(ɛ, log2_length, 8.0,
+    max_scale, 4, nOctaves)
 # error if max_qualityfactor is strictly smaller than 1.0
 @test_throws ErrorException checkspec(ɛ, log2_length, 0.9,
     max_scale, nFilters_per_octave, nOctaves)
@@ -44,9 +41,6 @@ nOctaves = 8
 # error if nFilters_per_octave < 1
 @test_throws ErrorException checkspec(ɛ, log2_length, max_qualityfactor,
     max_scale, 0, nOctaves)
-# error if max_qualityfactor > nFilters_per_octave
-@test_throws ErrorException checkspec(ɛ, log2_length, 8.0,
-    max_scale, 4, nOctaves)
 
 # realtype
 @test realtype(Float32) == Float32

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -1,40 +1,40 @@
-import WaveletScattering: AbstractSpec, AbstractSpec1D, AbstractSpec2D,
+import WaveletScattering: AbstractSpec, Abstract1DSpec, Abstract2DSpec,
                           specgammas
 
-immutable TestSpec1D <: AbstractSpec1D
+immutable Test1DSpec <: Abstract1DSpec
     nFilters_per_octave::Int
     nOctaves::Int
 end
-immutable TestSpec2D <: AbstractSpec2D
+immutable Test2DSpec <: Abstract2DSpec
     nFilters_per_octave::Int
     nOctaves::Int
     nOrientations::Int
 end
 
 # abstract subtype testing
-@test TestSpec1D <: AbstractSpec
-@test TestSpec2D <: AbstractSpec
+@test Test1DSpec <: AbstractSpec
+@test Test2DSpec <: AbstractSpec
 
 # specgammas
-spec = TestSpec1D(1, 1)
+spec = Test1DSpec(1, 1)
 (γs, χs, js) = specgammas(spec)
 @test γs == [0]
 @test χs == [0]
 @test js == [0]
 
-spec = TestSpec1D(2, 1)
+spec = Test1DSpec(2, 1)
 (γs, χs, js) = specgammas(spec)
 @test γs == [0, 1]
 @test χs == [0, 1]
 @test js == [0, 0]
 
-spec = TestSpec1D(1, 2)
+spec = Test1DSpec(1, 2)
 (γs, χs, js) = specgammas(spec)
 @test γs == [0, 1]
 @test χs == [0, 0]
 @test js == [0, 1]
 
-spec = TestSpec1D(12, 8)
+spec = Test1DSpec(12, 8)
 (γs, χs, js) = specgammas(spec)
 nWavelets = spec.nFilters_per_octave * spec.nOctaves
 @test length(γs) == nWavelets

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -1,5 +1,5 @@
 import WaveletScattering: AbstractSpec, Abstract1DSpec, Abstract2DSpec,
-                          realtype, specgammas
+                          checkspec, realtype, specgammas
 
 immutable Test1DSpec <: Abstract1DSpec
     nFilters_per_octave::Int
@@ -14,6 +14,21 @@ end
 # abstract subtype testing
 @test Test1DSpec <: AbstractSpec
 @test Test2DSpec <: AbstractSpec
+
+# checkspec
+opts = @options max_qualityfactor=2.0 max_nFilters_per_octave=4
+@test checkopts(opts) == nothing
+opts = @options max_qualityfactor=0.5 max_nFilters_per_octave=4
+@test_throws ErrorException checkopts(opts)
+opts = @options max_qualityfactor=8.0 max_nFilters_per_octave=4
+@test_throws ErrorException checkopts(opts)
+
+# realtype
+@test realtype(Float32) == Float32
+@test realtype(Float64) == Float64
+@test realtype(Complex{Float32}) == Float32
+@test realtype(Complex{Float64}) == Float64
+@test_throws MethodError realtype(ASCIIString)
 
 # specgammas
 spec = Test1DSpec(1, 1)
@@ -40,10 +55,3 @@ nWavelets = spec.nFilters_per_octave * spec.nOctaves
 @test length(γs) == nWavelets
 @test length(χs) == nWavelets
 @test length(js) == nWavelets
-
-# realtype
-@test realtype(Float32) == Float32
-@test realtype(Float64) == Float64
-@test realtype(Complex{Float32}) == Float32
-@test realtype(Complex{Float64}) == Float64
-@test_throws MethodError realtype(ASCIIString)

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -1,5 +1,5 @@
 import WaveletScattering: AbstractSpec, Abstract1DSpec, Abstract2DSpec,
-                          checkspec, realtype, specgammas
+                          checkspec, default_epsilon, realtype, specgammas
 
 # checkspec
 ɛ = eps(Float32)

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -17,11 +17,11 @@ end
 
 # checkspec
 opts = @options max_qualityfactor=2.0 max_nFilters_per_octave=4
-@test checkopts(opts) == nothing
+@test checkspec(opts) == nothing
 opts = @options max_qualityfactor=0.5 max_nFilters_per_octave=4
-@test_throws ErrorException checkopts(opts)
+@test_throws ErrorException checkspec(opts)
 opts = @options max_qualityfactor=8.0 max_nFilters_per_octave=4
-@test_throws ErrorException checkopts(opts)
+@test_throws ErrorException checkspec(opts)
 
 # realtype
 @test realtype(Float32) == Float32

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -10,37 +10,37 @@ nFilters_per_octave = 12
 nOctaves = 8
 # normal behavior
 @test checkspec(ɛ, log2_length, max_qualityfactor,
-    max_scale, nFilters_per_octave, nOctaves)
+                max_scale, nFilters_per_octave, nOctaves)
 # error if ɛ is strictly negative zero
 @test_throws ErrorException checkspec(-1.0, log2_length, max_qualityfactor,
-    max_scale, nFilters_per_octave, nOctaves)
+                                      max_scale, nFilters_per_octave, nOctaves)
 # error if ɛ equal or greater than one
 @test_throws ErrorException checkspec(1.0, log2_length, max_qualityfactor,
-    max_scale, nFilters_per_octave, nOctaves)
+                                      max_scale, nFilters_per_octave, nOctaves)
 # error if log2_length is smaller than 2
 @test_throws ErrorException checkspec(ɛ, 1, max_qualityfactor,
-    max_scale, nFilters_per_octave, nOctaves)
+                                      max_scale, nFilters_per_octave, nOctaves)
 # error if nOctaves is smaller than 1
 @test_throws ErrorException checkspec(ɛ, log2_length, max_qualityfactor,
-    max_scale, nFilters_per_octave, 0)
+                                      max_scale, nFilters_per_octave, 0)
 # error if the difference (log2_length-nOctaves) is smaller than 2
 @test_throws ErrorException checkspec(ɛ, 9, max_qualityfactor,
-    max_scale, 1, 8)
+                                      max_scale, 1, 8)
 # error if log2_length-nOctaves <= log2(nFilters_per_octave)
 @test_throws ErrorException checkspec(ɛ, 12, max_qualityfactor,
-    max_scale, 32, 9)
+                                      max_scale, 32, 9)
 # error if max_qualityfactor > nFilters_per_octave
 @test_throws ErrorException checkspec(ɛ, log2_length, 8.0,
-    max_scale, 4, nOctaves)
+                                      max_scale, 4, nOctaves)
 # error if max_qualityfactor is strictly smaller than 1.0
 @test_throws ErrorException checkspec(ɛ, log2_length, 0.9,
-    max_scale, nFilters_per_octave, nOctaves)
+                                      max_scale, nFilters_per_octave, nOctaves)
 # error if max_scale < (5.0*max_qualityfactor)
 @test_throws ErrorException checkspec(ɛ, log2_length, 32.0,
-    100.0, nFilters_per_octave, nOctaves)
+                                      100.0, nFilters_per_octave, nOctaves)
 # error if nFilters_per_octave < 1
 @test_throws ErrorException checkspec(ɛ, log2_length, max_qualityfactor,
-    max_scale, 0, nOctaves)
+                                      max_scale, 0, nOctaves)
 
 # default_epsilon
 @test_approx_eq default_epsilon(Float16) 1e-3

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -42,12 +42,13 @@ nOctaves = 8
 @test_throws ErrorException checkspec(ɛ, log2_length, max_qualityfactor,
     max_scale, 0, nOctaves)
 
-# realtype
-@test realtype(Float32) == Float32
-@test realtype(Float64) == Float64
-@test realtype(Complex{Float32}) == Float32
-@test realtype(Complex{Float64}) == Float64
-@test_throws MethodError realtype(ASCIIString)
+# default_epsilon
+@test_approx_eq default_epsilon(Float16) 1e-3
+@test_approx_eq default_epsilon(Float32) 1e-7
+@test_approx_eq default_epsilon(Float64) 1e-15
+@test_approx_eq default_epsilon(Complex{Float16}) 1e-3
+@test_approx_eq default_epsilon(Complex{Float32}) 1e-7
+@test_approx_eq default_epsilon(Complex{Float64}) 1e-15
 
 # specgammas
 immutable Test1DSpec <: Abstract1DSpec

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -1,5 +1,5 @@
 import WaveletScattering: AbstractSpec, Abstract1DSpec, Abstract2DSpec,
-                          specgammas
+                          realtype, specgammas
 
 immutable Test1DSpec <: Abstract1DSpec
     nFilters_per_octave::Int

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -16,12 +16,13 @@ end
 @test Test2DSpec <: AbstractSpec
 
 # checkspec
-opts = @options max_qualityfactor=2.0 nFilters_per_octave=4
-@test checkspec(opts) == nothing
-opts = @options max_qualityfactor=0.5 nFilters_per_octave=4
-@test_throws ErrorException checkspec(opts)
-opts = @options max_qualityfactor=8.0 nFilters_per_octave=4
-@test_throws ErrorException checkspec(opts)
+max_qualityfactor = 2.0
+nFilters_per_octave = 4
+@test checkspec(max_qualityfactor, nFilters_per_octave) == nothing
+max_qualityfactor = 0.5
+@test_throws ErrorException checkspec(max_qualityfactor, nFilters_per_octave)
+max_qualityfactor = 8.0
+@test_throws ErrorException checkspec(max_qualityfactor, nFilters_per_octave)
 
 # realtype
 @test realtype(Float32) == Float32

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -1,20 +1,6 @@
 import WaveletScattering: AbstractSpec, Abstract1DSpec, Abstract2DSpec,
                           checkspec, realtype, specgammas
 
-immutable Test1DSpec <: Abstract1DSpec
-    nFilters_per_octave::Int
-    nOctaves::Int
-end
-immutable Test2DSpec <: Abstract2DSpec
-    nFilters_per_octave::Int
-    nOctaves::Int
-    nOrientations::Int
-end
-
-# abstract subtype testing
-@test Test1DSpec <: AbstractSpec
-@test Test2DSpec <: AbstractSpec
-
 # checkspec
 ɛ = eps(Float32)
 log2_length = 15
@@ -70,6 +56,10 @@ nOctaves = 8
 @test_throws MethodError realtype(ASCIIString)
 
 # specgammas
+immutable Test1DSpec <: Abstract1DSpec
+    nFilters_per_octave::Int
+    nOctaves::Int
+end
 spec = Test1DSpec(1, 1)
 (γs, χs, js) = specgammas(spec)
 @test γs == [0]

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -40,3 +40,10 @@ nWavelets = spec.nFilters_per_octave * spec.nOctaves
 @test length(γs) == nWavelets
 @test length(χs) == nWavelets
 @test length(js) == nWavelets
+
+# realtype
+@test realtype(Float32) == Float32
+@test realtype(Float64) == Float64
+@test realtype(Complex{Float32}) == Float32
+@test realtype(Complex{Float64}) == Float64
+@test_throws MethodError realtype(ASCIIString)

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -50,6 +50,13 @@ nOctaves = 8
 @test_approx_eq default_epsilon(Complex{Float32}) 1e-7
 @test_approx_eq default_epsilon(Complex{Float64}) 1e-15
 
+# realtype
+@test realtype(Float32) == Float32
+@test realtype(Float64) == Float64
+@test realtype(Complex{Float32}) == Float32
+@test realtype(Complex{Float64}) == Float64
+@test_throws MethodError realtype(ASCIIString)
+
 # specgammas
 immutable Test1DSpec <: Abstract1DSpec
     nFilters_per_octave::Int


### PR DESCRIPTION
This PR adds a constructor for the concrete type `Morlet1DSpec`.
The function `checkspec` is called by the inner constructor to verify that keyword arguments will generate a valid filter bank. The function `localize` yields bandwidths, center frequencies, quality factors, and scales for the corresponding Morlet wavelets.
Tests included.
